### PR TITLE
MAINT: make q2_types.tests a package

### DIFF
--- a/q2_types/tests/__init__.py
+++ b/q2_types/tests/__init__.py
@@ -1,0 +1,7 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------


### PR DESCRIPTION
Once we start using pkg_resources to locate test data files, tests will need to be in a package.