### PR TITLE
BUG: DNAIterator -> DNAFASTAFormat now uses generator

### DIFF
--- a/q2_types/feature_data/_transformer.py
+++ b/q2_types/feature_data/_transformer.py
@@ -79,7 +79,7 @@ def _9(ff: DNAFASTAFormat) -> DNAIterator:
 @plugin.register_transformer
 def _10(data: DNAIterator) -> DNAFASTAFormat:
     ff = DNAFASTAFormat()
-    skbio.io.write(data, format='fasta', into=str(ff))
+    skbio.io.write(data.generator, format='fasta', into=str(ff))
     return ff
 
 


### PR DESCRIPTION
`DNAIterator` wraps a generator (so that transformer registration works). The `DNAIterator` -> `DNAFastaFormat` transformer was not accessing the wrapped generator. Now it does.