### PR TITLE
BUG: bootstrap matplotib config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
   - source activate test-env
   - pip install https://github.com/qiime2/qiime2/archive/master.zip
   - pip install .
+  - echo "backend: Agg" > matplotlibrc
 script:
   - nosetests
   - flake8 q2_types setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - source activate test-env
   - pip install https://github.com/qiime2/qiime2/archive/master.zip
   - pip install .
-  - echo "backend: Agg" > matplotlibrc
+  - 'echo "backend: Agg" > matplotlibrc'
 script:
   - nosetests
   - flake8 q2_types setup.py


### PR DESCRIPTION
Explicitly set the matplotlib backend to `Agg`, due to a QT dependency mismatch in conda's distribution of matplotlib.