### PR TITLE
FIX/REF: Remove dupe BIOM registration, register formats

### DIFF
--- a/q2_types/distance_matrix/_format.py
+++ b/q2_types/distance_matrix/_format.py
@@ -22,5 +22,4 @@ DistanceMatrixDirectoryFormat = model.SingleFileDirectoryFormat(
     'DistanceMatrixDirectoryFormat', 'distance-matrix.tsv', LSMatFormat)
 
 
-plugin.register_format(LSMatFormat)
-plugin.register_format(DistanceMatrixDirectoryFormat)
+plugin.register_formats(LSMatFormat, DistanceMatrixDirectoryFormat)

--- a/q2_types/distance_matrix/_format.py
+++ b/q2_types/distance_matrix/_format.py
@@ -9,6 +9,8 @@
 import skbio.io
 import qiime.plugin.model as model
 
+from ..plugin_setup import plugin
+
 
 class LSMatFormat(model.TextFileFormat):
     def sniff(self):
@@ -18,3 +20,7 @@ class LSMatFormat(model.TextFileFormat):
 
 DistanceMatrixDirectoryFormat = model.SingleFileDirectoryFormat(
     'DistanceMatrixDirectoryFormat', 'distance-matrix.tsv', LSMatFormat)
+
+
+plugin.register_format(LSMatFormat)
+plugin.register_format(DistanceMatrixDirectoryFormat)

--- a/q2_types/distance_matrix/_type.py
+++ b/q2_types/distance_matrix/_type.py
@@ -14,7 +14,7 @@ from . import DistanceMatrixDirectoryFormat
 
 DistanceMatrix = SemanticType('DistanceMatrix')
 
-plugin.register_semantic_type(DistanceMatrix)
+plugin.register_semantic_types(DistanceMatrix)
 plugin.register_semantic_type_to_format(
     DistanceMatrix,
     artifact_format=DistanceMatrixDirectoryFormat

--- a/q2_types/feature_data/_format.py
+++ b/q2_types/feature_data/_format.py
@@ -9,6 +9,8 @@
 import skbio.io
 import qiime.plugin.model as model
 
+from ..plugin_setup import plugin
+
 
 class TaxonomyFormat(model.TextFileFormat):
     def sniff(self):
@@ -84,3 +86,12 @@ class AlignedDNAFASTAFormat(model.TextFileFormat):
 AlignedDNASequencesDirectoryFormat = model.SingleFileDirectoryFormat(
     'AlignedDNASequencesDirectoryFormat', 'aligned-dna-sequences.fasta',
     AlignedDNAFASTAFormat)
+
+
+plugin.register_format(TaxonomyFormat)
+plugin.register_format(TaxonomyDirectoryFormat)
+plugin.register_format(DNAFASTAFormat)
+plugin.register_format(DNASequencesDirectoryFormat)
+plugin.register_format(PairedDNASequencesDirectoryFormat)
+plugin.register_format(AlignedDNAFASTAFormat)
+plugin.register_format(AlignedDNASequencesDirectoryFormat)

--- a/q2_types/feature_data/_format.py
+++ b/q2_types/feature_data/_format.py
@@ -88,10 +88,8 @@ AlignedDNASequencesDirectoryFormat = model.SingleFileDirectoryFormat(
     AlignedDNAFASTAFormat)
 
 
-plugin.register_format(TaxonomyFormat)
-plugin.register_format(TaxonomyDirectoryFormat)
-plugin.register_format(DNAFASTAFormat)
-plugin.register_format(DNASequencesDirectoryFormat)
-plugin.register_format(PairedDNASequencesDirectoryFormat)
-plugin.register_format(AlignedDNAFASTAFormat)
-plugin.register_format(AlignedDNASequencesDirectoryFormat)
+plugin.register_formats(
+    TaxonomyFormat, TaxonomyDirectoryFormat, DNAFASTAFormat,
+    DNASequencesDirectoryFormat, PairedDNASequencesDirectoryFormat,
+    AlignedDNAFASTAFormat, AlignedDNASequencesDirectoryFormat
+)

--- a/q2_types/feature_data/_type.py
+++ b/q2_types/feature_data/_type.py
@@ -26,11 +26,8 @@ PairedEndSequence = SemanticType('PairedEndSequence',
 AlignedSequence = SemanticType('AlignedSequence',
                                variant_of=FeatureData.field['type'])
 
-plugin.register_semantic_type(FeatureData)
-plugin.register_semantic_type(Taxonomy)
-plugin.register_semantic_type(Sequence)
-plugin.register_semantic_type(PairedEndSequence)
-plugin.register_semantic_type(AlignedSequence)
+plugin.register_semantic_types(FeatureData, Taxonomy, Sequence,
+                               PairedEndSequence, AlignedSequence)
 
 plugin.register_semantic_type_to_format(
     FeatureData[Taxonomy],

--- a/q2_types/feature_table/_format.py
+++ b/q2_types/feature_table/_format.py
@@ -10,6 +10,8 @@ import h5py
 
 import qiime.plugin.model as model
 
+from ..plugin_setup import plugin
+
 
 class BIOMV100Format(model.TextFileFormat):
     top_level_keys = {
@@ -85,3 +87,8 @@ BIOMV100DirFmt = model.SingleFileDirectoryFormat('BIOMV100DirFmt',
 BIOMV210DirFmt = model.SingleFileDirectoryFormat('BIOMV210DirFmt',
                                                  'feature-table.biom',
                                                  BIOMV210Format)
+
+plugin.register_format(BIOMV100Format)
+plugin.register_format(BIOMV210Format)
+plugin.register_format(BIOMV100DirFmt)
+plugin.register_format(BIOMV210DirFmt)

--- a/q2_types/feature_table/_format.py
+++ b/q2_types/feature_table/_format.py
@@ -88,7 +88,6 @@ BIOMV210DirFmt = model.SingleFileDirectoryFormat('BIOMV210DirFmt',
                                                  'feature-table.biom',
                                                  BIOMV210Format)
 
-plugin.register_format(BIOMV100Format)
-plugin.register_format(BIOMV210Format)
-plugin.register_format(BIOMV100DirFmt)
-plugin.register_format(BIOMV210DirFmt)
+plugin.register_formats(
+    BIOMV100Format, BIOMV210Format, BIOMV100DirFmt, BIOMV210DirFmt
+)

--- a/q2_types/feature_table/_type.py
+++ b/q2_types/feature_table/_type.py
@@ -9,7 +9,7 @@
 from qiime.plugin import SemanticType
 
 from ..plugin_setup import plugin
-from . import BIOMV100DirFmt, BIOMV210DirFmt
+from . import BIOMV210DirFmt
 
 
 FeatureTable = SemanticType('FeatureTable', field_names='content')
@@ -31,9 +31,4 @@ plugin.register_semantic_type(PresenceAbsence)
 plugin.register_semantic_type_to_format(
     FeatureTable[Frequency | RelativeFrequency | PresenceAbsence],
     artifact_format=BIOMV210DirFmt
-)
-
-plugin.register_semantic_type_to_format(
-    FeatureTable[Frequency | RelativeFrequency | PresenceAbsence],
-    artifact_format=BIOMV100DirFmt
 )

--- a/q2_types/feature_table/_type.py
+++ b/q2_types/feature_table/_type.py
@@ -23,10 +23,8 @@ PresenceAbsence = SemanticType('PresenceAbsence',
                                variant_of=FeatureTable.field['content'])
 
 
-plugin.register_semantic_type(FeatureTable)
-plugin.register_semantic_type(Frequency)
-plugin.register_semantic_type(RelativeFrequency)
-plugin.register_semantic_type(PresenceAbsence)
+plugin.register_semantic_types(FeatureTable, Frequency, RelativeFrequency,
+                               PresenceAbsence)
 
 plugin.register_semantic_type_to_format(
     FeatureTable[Frequency | RelativeFrequency | PresenceAbsence],

--- a/q2_types/ordination/_format.py
+++ b/q2_types/ordination/_format.py
@@ -22,5 +22,4 @@ OrdinationDirectoryFormat = model.SingleFileDirectoryFormat(
     'OrdinationDirectoryFormat', 'ordination.txt', OrdinationFormat)
 
 
-plugin.register_format(OrdinationFormat)
-plugin.register_format(OrdinationDirectoryFormat)
+plugin.register_formats(OrdinationFormat, OrdinationDirectoryFormat)

--- a/q2_types/ordination/_format.py
+++ b/q2_types/ordination/_format.py
@@ -9,6 +9,8 @@
 import skbio.io
 import qiime.plugin.model as model
 
+from ..plugin_setup import plugin
+
 
 class OrdinationFormat(model.TextFileFormat):
     def sniff(self):
@@ -18,3 +20,7 @@ class OrdinationFormat(model.TextFileFormat):
 
 OrdinationDirectoryFormat = model.SingleFileDirectoryFormat(
     'OrdinationDirectoryFormat', 'ordination.txt', OrdinationFormat)
+
+
+plugin.register_format(OrdinationFormat)
+plugin.register_format(OrdinationDirectoryFormat)

--- a/q2_types/ordination/_type.py
+++ b/q2_types/ordination/_type.py
@@ -14,7 +14,7 @@ from . import OrdinationDirectoryFormat
 
 PCoAResults = SemanticType('PCoAResults')
 
-plugin.register_semantic_type(PCoAResults)
+plugin.register_semantic_types(PCoAResults)
 plugin.register_semantic_type_to_format(
     PCoAResults,
     artifact_format=OrdinationDirectoryFormat

--- a/q2_types/per_sample_sequences/_format.py
+++ b/q2_types/per_sample_sequences/_format.py
@@ -76,10 +76,9 @@ class SingleLanePerSamplePairedEndFastqDirFmt(_SingleLanePerSampleFastqDirFmt):
     pass
 
 
-plugin.register_format(FastqManifestFormat)
-plugin.register_format(YamlFormat)
-plugin.register_format(FastqGzFormat)
-plugin.register_format(CasavaOneEightSingleLanePerSampleDirFmt)
-plugin.register_format(_SingleLanePerSampleFastqDirFmt)
-plugin.register_format(SingleLanePerSampleSingleEndFastqDirFmt)
-plugin.register_format(SingleLanePerSamplePairedEndFastqDirFmt)
+plugin.register_formats(
+    FastqManifestFormat, YamlFormat, FastqGzFormat,
+    CasavaOneEightSingleLanePerSampleDirFmt, _SingleLanePerSampleFastqDirFmt,
+    SingleLanePerSampleSingleEndFastqDirFmt,
+    SingleLanePerSamplePairedEndFastqDirFmt
+)

--- a/q2_types/per_sample_sequences/_format.py
+++ b/q2_types/per_sample_sequences/_format.py
@@ -10,6 +10,8 @@ import skbio.io
 import yaml
 import qiime.plugin.model as model
 
+from ..plugin_setup import plugin
+
 
 class FastqManifestFormat(model.TextFileFormat):
     """
@@ -72,3 +74,12 @@ class SingleLanePerSamplePairedEndFastqDirFmt(_SingleLanePerSampleFastqDirFmt):
     # SingleLanePerSampleSingleEndFastqDirFmt (canonically pronounced,
     # SLPSSEFDF) until we have validation.
     pass
+
+
+plugin.register_format(FastqManifestFormat)
+plugin.register_format(YamlFormat)
+plugin.register_format(FastqGzFormat)
+plugin.register_format(CasavaOneEightSingleLanePerSampleDirFmt)
+plugin.register_format(_SingleLanePerSampleFastqDirFmt)
+plugin.register_format(SingleLanePerSampleSingleEndFastqDirFmt)
+plugin.register_format(SingleLanePerSamplePairedEndFastqDirFmt)

--- a/q2_types/per_sample_sequences/_type.py
+++ b/q2_types/per_sample_sequences/_type.py
@@ -19,8 +19,8 @@ SequencesWithQuality = SemanticType(
 PairedEndSequencesWithQuality = SemanticType(
     'PairedEndSequencesWithQuality', variant_of=SampleData.field['type'])
 
-plugin.register_semantic_type(SequencesWithQuality)
-plugin.register_semantic_type(PairedEndSequencesWithQuality)
+plugin.register_semantic_types(SequencesWithQuality,
+                               PairedEndSequencesWithQuality)
 
 plugin.register_semantic_type_to_format(
     SampleData[SequencesWithQuality],

--- a/q2_types/reference_features/_format.py
+++ b/q2_types/reference_features/_format.py
@@ -11,6 +11,7 @@ import qiime.plugin.model as model
 from ..feature_data import (DNAFASTAFormat, AlignedDNAFASTAFormat,
                             TaxonomyFormat)
 from ..tree import NewickFormat
+from ..plugin_setup import plugin
 
 
 class ReferenceFeaturesDirectoryFormat(model.DirectoryFormat):
@@ -19,3 +20,6 @@ class ReferenceFeaturesDirectoryFormat(model.DirectoryFormat):
                                        format=AlignedDNAFASTAFormat)
     taxonomy = model.File('taxonomy.tsv', format=TaxonomyFormat)
     tree = model.File('tree.nwk', format=NewickFormat)
+
+
+plugin.register_format(ReferenceFeaturesDirectoryFormat)

--- a/q2_types/reference_features/_format.py
+++ b/q2_types/reference_features/_format.py
@@ -22,4 +22,4 @@ class ReferenceFeaturesDirectoryFormat(model.DirectoryFormat):
     tree = model.File('tree.nwk', format=NewickFormat)
 
 
-plugin.register_format(ReferenceFeaturesDirectoryFormat)
+plugin.register_formats(ReferenceFeaturesDirectoryFormat)

--- a/q2_types/reference_features/_type.py
+++ b/q2_types/reference_features/_type.py
@@ -15,8 +15,7 @@ from . import ReferenceFeaturesDirectoryFormat
 ReferenceFeatures = SemanticType('ReferenceFeatures', field_names='type')
 SSU = SemanticType('SSU', variant_of=ReferenceFeatures.field['type'])
 
-plugin.register_semantic_type(ReferenceFeatures)
-plugin.register_semantic_type(SSU)
+plugin.register_semantic_types(ReferenceFeatures, SSU)
 
 plugin.register_semantic_type_to_format(
     ReferenceFeatures[SSU],

--- a/q2_types/sample_data/_format.py
+++ b/q2_types/sample_data/_format.py
@@ -26,5 +26,4 @@ AlphaDiversityDirectoryFormat = model.SingleFileDirectoryFormat(
     AlphaDiversityFormat)
 
 
-plugin.register_format(AlphaDiversityFormat)
-plugin.register_format(AlphaDiversityDirectoryFormat)
+plugin.register_formats(AlphaDiversityFormat, AlphaDiversityDirectoryFormat)

--- a/q2_types/sample_data/_format.py
+++ b/q2_types/sample_data/_format.py
@@ -8,6 +8,8 @@
 
 import qiime.plugin.model as model
 
+from ..plugin_setup import plugin
+
 
 class AlphaDiversityFormat(model.TextFileFormat):
     def sniff(self):
@@ -22,3 +24,7 @@ class AlphaDiversityFormat(model.TextFileFormat):
 AlphaDiversityDirectoryFormat = model.SingleFileDirectoryFormat(
     'AlphaDiversityDirectoryFormat', 'alpha-diversity.tsv',
     AlphaDiversityFormat)
+
+
+plugin.register_format(AlphaDiversityFormat)
+plugin.register_format(AlphaDiversityDirectoryFormat)

--- a/q2_types/sample_data/_type.py
+++ b/q2_types/sample_data/_type.py
@@ -17,8 +17,7 @@ SampleData = SemanticType('SampleData', field_names='type')
 AlphaDiversity = SemanticType('AlphaDiversity',
                               variant_of=SampleData.field['type'])
 
-plugin.register_semantic_type(SampleData)
-plugin.register_semantic_type(AlphaDiversity)
+plugin.register_semantic_types(SampleData, AlphaDiversity)
 
 plugin.register_semantic_type_to_format(
     SampleData[AlphaDiversity],

--- a/q2_types/tree/_format.py
+++ b/q2_types/tree/_format.py
@@ -9,6 +9,8 @@
 import skbio.io
 import qiime.plugin.model as model
 
+from ..plugin_setup import plugin
+
 
 class NewickFormat(model.TextFileFormat):
     def sniff(self):
@@ -18,3 +20,7 @@ class NewickFormat(model.TextFileFormat):
 
 NewickDirectoryFormat = model.SingleFileDirectoryFormat(
     'NewickDirectoryFormat', 'tree.nwk', NewickFormat)
+
+
+plugin.register_format(NewickFormat)
+plugin.register_format(NewickDirectoryFormat)

--- a/q2_types/tree/_format.py
+++ b/q2_types/tree/_format.py
@@ -22,5 +22,4 @@ NewickDirectoryFormat = model.SingleFileDirectoryFormat(
     'NewickDirectoryFormat', 'tree.nwk', NewickFormat)
 
 
-plugin.register_format(NewickFormat)
-plugin.register_format(NewickDirectoryFormat)
+plugin.register_formats(NewickFormat, NewickDirectoryFormat)

--- a/q2_types/tree/_type.py
+++ b/q2_types/tree/_type.py
@@ -18,9 +18,7 @@ Rooted = SemanticType('Rooted', variant_of=Phylogeny.field['type'])
 
 Unrooted = SemanticType('Unrooted', variant_of=Phylogeny.field['type'])
 
-plugin.register_semantic_type(Phylogeny)
-plugin.register_semantic_type(Rooted)
-plugin.register_semantic_type(Unrooted)
+plugin.register_semantic_types(Phylogeny, Rooted, Unrooted)
 
 plugin.register_semantic_type_to_format(Phylogeny[Rooted | Unrooted],
                                         artifact_format=NewickDirectoryFormat)


### PR DESCRIPTION
Removes duplicate `BIOMV100DirFmt` registration.
Adds explicit format registration to the plugin object as per qiime2/qiime2/pull/159.

***This will fail testing until the `qiime2` PR is merged.***

Resolves #56 