### PR TITLE
ENH: new date-based versioning; `qiime` -> `qiime2` package rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ install:
   - pip install flake8
   - pip install .
   - 'echo "backend: Agg" > matplotlibrc'
+  - git clone https://github.com/qiime2/q2lint
 script:
   - nosetests
   - flake8
+  - python q2lint/q2lint.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,12 @@ install:
   # we can let conda do dependency resolution when there are conda packages for
   # the various QIIME 2 projects. Until then, avoid installing heavyweight
   # dependencies via pip.
-  - conda create --yes -n test-env -c biocore python=$PYTHON_VERSION scikit-bio jupyter click nose flake8
+  - conda create --yes -n test-env -c biocore python=$PYTHON_VERSION scikit-bio jupyter click nose
   - source activate test-env
   - pip install https://github.com/qiime2/qiime2/archive/master.zip
+  - pip install flake8
   - pip install .
   - 'echo "backend: Agg" > matplotlibrc'
 script:
   - nosetests
-  - flake8 q2_types setup.py
+  - flake8

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2016--, QIIME 2 development team.
+BSD 3-Clause License
+
+Copyright (c) 2016-2017, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -11,7 +13,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of qiime2 nor the names of its
+* Neither the name of the copyright holder nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016, QIIME 2 Development Team
+Copyright (c) 2016--, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -11,7 +11,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of q2-types nor the names of its
+* Neither the name of qiime2 nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/q2_types/__init__.py
+++ b/q2_types/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/__init__.py
+++ b/q2_types/__init__.py
@@ -1,12 +1,13 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+import pkg_resources
 
-__version__ = "0.0.7.dev0"  # noqa
+__version__ = pkg_resources.get_distribution('q2-types').version
 
 # TODO remove all imports and from __all__ because they are available as public
 # imports in their respective subpackages. These imports are here so the

--- a/q2_types/__init__.py
+++ b/q2_types/__init__.py
@@ -5,30 +5,18 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+
+import importlib
 import pkg_resources
 
 __version__ = pkg_resources.get_distribution('q2-types').version
 
-# TODO remove all imports and from __all__ because they are available as public
-# imports in their respective subpackages. These imports are here so the
-# existing tests will pass; they can be removed when the tests are rewritten.
 
-from .feature_table import (FeatureTable, Frequency, RelativeFrequency,
-                            PresenceAbsence)
-from .distance_matrix import DistanceMatrix
-from .sample_data import SampleData, AlphaDiversity
-from .tree import Phylogeny, Rooted, Unrooted
-from .ordination import PCoAResults
-from .feature_data import (FeatureData, Taxonomy, Sequence, PairedEndSequence,
-                           AlignedSequence, DNAIterator, PairedDNAIterator)
-from .reference_features import ReferenceFeatures, SSU
-from .per_sample_sequences import (SequencesWithQuality,
-                                   PairedEndSequencesWithQuality)
-
-__all__ = ['DistanceMatrix', 'Phylogeny', 'PCoAResults', 'FeatureTable',
-           'Frequency', 'RelativeFrequency', 'PresenceAbsence',
-           'SampleData', 'AlphaDiversity', 'FeatureData', 'Taxonomy',
-           'Sequence', 'PairedEndSequence', 'AlignedSequence',
-           'ReferenceFeatures', 'SSU', 'Rooted', 'Unrooted', 'DNAIterator',
-           'PairedDNAIterator', 'SequencesWithQuality',
-           'PairedEndSequencesWithQuality']
+importlib.import_module('q2_types.feature_table')
+importlib.import_module('q2_types.distance_matrix')
+importlib.import_module('q2_types.tree')
+importlib.import_module('q2_types.ordination')
+importlib.import_module('q2_types.sample_data')
+importlib.import_module('q2_types.feature_data')
+importlib.import_module('q2_types.reference_features')
+importlib.import_module('q2_types.per_sample_sequences')

--- a/q2_types/distance_matrix/__init__.py
+++ b/q2_types/distance_matrix/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/distance_matrix/__init__.py
+++ b/q2_types/distance_matrix/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/distance_matrix/_format.py
+++ b/q2_types/distance_matrix/_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/distance_matrix/_format.py
+++ b/q2_types/distance_matrix/_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 import skbio.io
-import qiime.plugin.model as model
+import qiime2.plugin.model as model
 
 from ..plugin_setup import plugin
 

--- a/q2_types/distance_matrix/_transformer.py
+++ b/q2_types/distance_matrix/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/distance_matrix/_transformer.py
+++ b/q2_types/distance_matrix/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/distance_matrix/_type.py
+++ b/q2_types/distance_matrix/_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/distance_matrix/_type.py
+++ b/q2_types/distance_matrix/_type.py
@@ -1,12 +1,12 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime.plugin import SemanticType
+from qiime2.plugin import SemanticType
 
 from ..plugin_setup import plugin
 from . import DistanceMatrixDirectoryFormat

--- a/q2_types/distance_matrix/tests/__init__.py
+++ b/q2_types/distance_matrix/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/distance_matrix/tests/__init__.py
+++ b/q2_types/distance_matrix/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/distance_matrix/tests/test_format.py
+++ b/q2_types/distance_matrix/tests/test_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/distance_matrix/tests/test_format.py
+++ b/q2_types/distance_matrix/tests/test_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -11,7 +11,7 @@ import shutil
 import unittest
 
 from q2_types.distance_matrix import LSMatFormat, DistanceMatrixDirectoryFormat
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestFormats(TestPluginBase):

--- a/q2_types/distance_matrix/tests/test_transformer.py
+++ b/q2_types/distance_matrix/tests/test_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/distance_matrix/tests/test_transformer.py
+++ b/q2_types/distance_matrix/tests/test_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -11,7 +11,7 @@ import unittest
 import skbio
 
 from q2_types.distance_matrix import LSMatFormat
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestTransformers(TestPluginBase):

--- a/q2_types/distance_matrix/tests/test_type.py
+++ b/q2_types/distance_matrix/tests/test_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/distance_matrix/tests/test_type.py
+++ b/q2_types/distance_matrix/tests/test_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,7 +10,7 @@ import unittest
 
 from q2_types.distance_matrix import (DistanceMatrix,
                                       DistanceMatrixDirectoryFormat)
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestTypes(TestPluginBase):

--- a/q2_types/feature_data/__init__.py
+++ b/q2_types/feature_data/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_data/__init__.py
+++ b/q2_types/feature_data/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_data/_format.py
+++ b/q2_types/feature_data/_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_data/_format.py
+++ b/q2_types/feature_data/_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 import skbio.io
-import qiime.plugin.model as model
+import qiime2.plugin.model as model
 
 from ..plugin_setup import plugin
 

--- a/q2_types/feature_data/_transformer.py
+++ b/q2_types/feature_data/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_data/_transformer.py
+++ b/q2_types/feature_data/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -11,7 +11,7 @@ from itertools import zip_longest
 
 import pandas as pd
 import skbio
-import qiime
+import qiime2
 
 from ..plugin_setup import plugin
 from . import (TaxonomyFormat, DNAFASTAFormat,
@@ -70,9 +70,9 @@ def _6(ff: TaxonomyFormat) -> pd.Series:
 
 
 @plugin.register_transformer
-def _8(ff: TaxonomyFormat) -> qiime.Metadata:
+def _8(ff: TaxonomyFormat) -> qiime2.Metadata:
     data = _read_taxonomy(str(ff))
-    return qiime.Metadata(data)
+    return qiime2.Metadata(data)
 
 
 def _read_dna_fasta(path):

--- a/q2_types/feature_data/_type.py
+++ b/q2_types/feature_data/_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_data/_type.py
+++ b/q2_types/feature_data/_type.py
@@ -1,12 +1,12 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime.plugin import SemanticType
+from qiime2.plugin import SemanticType
 
 from ..plugin_setup import plugin
 from . import (TaxonomyDirectoryFormat, DNASequencesDirectoryFormat,

--- a/q2_types/feature_data/tests/__init__.py
+++ b/q2_types/feature_data/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_data/tests/__init__.py
+++ b/q2_types/feature_data/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_data/tests/test_format.py
+++ b/q2_types/feature_data/tests/test_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_data/tests/test_format.py
+++ b/q2_types/feature_data/tests/test_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -15,7 +15,7 @@ from q2_types.feature_data import (
     DNASequencesDirectoryFormat, PairedDNASequencesDirectoryFormat,
     AlignedDNAFASTAFormat, AlignedDNASequencesDirectoryFormat
 )
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestFormats(TestPluginBase):
@@ -99,6 +99,7 @@ class TestFormats(TestPluginBase):
         format = AlignedDNASequencesDirectoryFormat(temp_dir, mode='r')
 
         format.validate()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/q2_types/feature_data/tests/test_transformer.py
+++ b/q2_types/feature_data/tests/test_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_data/tests/test_transformer.py
+++ b/q2_types/feature_data/tests/test_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -9,7 +9,7 @@
 import unittest
 
 import pandas as pd
-import qiime
+import qiime2
 import skbio
 
 from pandas.util.testing import assert_frame_equal, assert_series_equal
@@ -17,7 +17,7 @@ from q2_types.feature_data import (
     TaxonomyFormat, DNAFASTAFormat, DNAIterator, PairedDNAIterator,
     PairedDNASequencesDirectoryFormat, AlignedDNAFASTAFormat
 )
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestTranfomers(TestPluginBase):
@@ -67,14 +67,14 @@ class TestTranfomers(TestPluginBase):
         assert_series_equal(obs, exp)
 
     def test_taxonomy_format_to_qiime_metadata(self):
-        input, obs = self.transform_format(TaxonomyFormat, qiime.Metadata,
+        input, obs = self.transform_format(TaxonomyFormat, qiime2.Metadata,
                                            filename='taxonomy.tsv')
 
         df = pd.read_csv(str(input), sep='\t',
                          comment='#', header=0, parse_dates=True,
                          skip_blank_lines=True, dtype=object)
         df.set_index(df.columns[0], drop=True, append=False, inplace=True)
-        exp = qiime.Metadata(df)
+        exp = qiime2.Metadata(df)
 
         assert_frame_equal(obs.to_dataframe(), exp.to_dataframe())
 

--- a/q2_types/feature_data/tests/test_type.py
+++ b/q2_types/feature_data/tests/test_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_data/tests/test_type.py
+++ b/q2_types/feature_data/tests/test_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -13,7 +13,7 @@ from q2_types.feature_data import (
     TaxonomyDirectoryFormat, DNASequencesDirectoryFormat,
     PairedDNASequencesDirectoryFormat, AlignedDNASequencesDirectoryFormat
 )
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestTypes(TestPluginBase):

--- a/q2_types/feature_table/__init__.py
+++ b/q2_types/feature_table/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_table/__init__.py
+++ b/q2_types/feature_table/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_table/_format.py
+++ b/q2_types/feature_table/_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_table/_format.py
+++ b/q2_types/feature_table/_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -8,7 +8,7 @@
 import ijson
 import h5py
 
-import qiime.plugin.model as model
+import qiime2.plugin.model as model
 
 from ..plugin_setup import plugin
 

--- a/q2_types/feature_table/_transformer.py
+++ b/q2_types/feature_table/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_table/_transformer.py
+++ b/q2_types/feature_table/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,7 +10,7 @@ import json
 
 import biom
 import pandas as pd
-import qiime
+import qiime2
 
 from . import BIOMV100Format, BIOMV210Format
 from ..feature_data import TaxonomyFormat
@@ -40,7 +40,7 @@ def _drop_axis_metadata(table):
 
 
 def _get_generated_by():
-    return 'qiime %s' % qiime.__version__
+    return 'qiime2 %s' % qiime2.__version__
 
 
 def _parse_biom_table_v100(ff):

--- a/q2_types/feature_table/_type.py
+++ b/q2_types/feature_table/_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_table/_type.py
+++ b/q2_types/feature_table/_type.py
@@ -1,12 +1,12 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime.plugin import SemanticType
+from qiime2.plugin import SemanticType
 
 from ..plugin_setup import plugin
 from . import BIOMV210DirFmt

--- a/q2_types/feature_table/tests/__init__.py
+++ b/q2_types/feature_table/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_table/tests/__init__.py
+++ b/q2_types/feature_table/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_table/tests/test_format.py
+++ b/q2_types/feature_table/tests/test_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_table/tests/test_format.py
+++ b/q2_types/feature_table/tests/test_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -12,7 +12,7 @@ import unittest
 
 from q2_types.feature_table import (BIOMV100Format, BIOMV210Format,
                                     BIOMV100DirFmt, BIOMV210DirFmt)
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestFormats(TestPluginBase):

--- a/q2_types/feature_table/tests/test_transformer.py
+++ b/q2_types/feature_table/tests/test_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_table/tests/test_transformer.py
+++ b/q2_types/feature_table/tests/test_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -14,7 +14,7 @@ import pandas as pd
 from pandas.util.testing import assert_frame_equal
 from q2_types.feature_table import BIOMV100Format, BIOMV210Format
 from q2_types.feature_data import TaxonomyFormat
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 from q2_types.feature_table._transformer import (_parse_biom_table_v100,
                                                  _parse_biom_table_v210,
                                                  _table_to_dataframe)

--- a/q2_types/feature_table/tests/test_type.py
+++ b/q2_types/feature_table/tests/test_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/feature_table/tests/test_type.py
+++ b/q2_types/feature_table/tests/test_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,7 +10,7 @@ import unittest
 
 from q2_types.feature_table import (FeatureTable, Frequency, RelativeFrequency,
                                     PresenceAbsence, BIOMV210DirFmt)
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestTypes(TestPluginBase):

--- a/q2_types/ordination/__init__.py
+++ b/q2_types/ordination/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/ordination/__init__.py
+++ b/q2_types/ordination/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/ordination/_format.py
+++ b/q2_types/ordination/_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/ordination/_format.py
+++ b/q2_types/ordination/_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 import skbio.io
-import qiime.plugin.model as model
+import qiime2.plugin.model as model
 
 from ..plugin_setup import plugin
 

--- a/q2_types/ordination/_transformer.py
+++ b/q2_types/ordination/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/ordination/_transformer.py
+++ b/q2_types/ordination/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/ordination/_type.py
+++ b/q2_types/ordination/_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/ordination/_type.py
+++ b/q2_types/ordination/_type.py
@@ -1,12 +1,12 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime.plugin import SemanticType
+from qiime2.plugin import SemanticType
 
 from ..plugin_setup import plugin
 from . import OrdinationDirectoryFormat

--- a/q2_types/ordination/tests/__init__.py
+++ b/q2_types/ordination/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/ordination/tests/__init__.py
+++ b/q2_types/ordination/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/ordination/tests/test_format.py
+++ b/q2_types/ordination/tests/test_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/ordination/tests/test_format.py
+++ b/q2_types/ordination/tests/test_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -11,7 +11,7 @@ import shutil
 import unittest
 
 from q2_types.ordination import OrdinationFormat, OrdinationDirectoryFormat
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestFormats(TestPluginBase):

--- a/q2_types/ordination/tests/test_transformer.py
+++ b/q2_types/ordination/tests/test_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/ordination/tests/test_transformer.py
+++ b/q2_types/ordination/tests/test_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -11,7 +11,7 @@ import unittest
 import skbio
 
 from q2_types.ordination import OrdinationFormat
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestTransformers(TestPluginBase):

--- a/q2_types/ordination/tests/test_type.py
+++ b/q2_types/ordination/tests/test_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/ordination/tests/test_type.py
+++ b/q2_types/ordination/tests/test_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -9,7 +9,7 @@
 import unittest
 
 from q2_types.ordination import PCoAResults, OrdinationDirectoryFormat
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestTypes(TestPluginBase):

--- a/q2_types/per_sample_sequences/__init__.py
+++ b/q2_types/per_sample_sequences/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/per_sample_sequences/__init__.py
+++ b/q2_types/per_sample_sequences/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/per_sample_sequences/_format.py
+++ b/q2_types/per_sample_sequences/_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/per_sample_sequences/_format.py
+++ b/q2_types/per_sample_sequences/_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -8,7 +8,7 @@
 
 import skbio.io
 import yaml
-import qiime.plugin.model as model
+import qiime2.plugin.model as model
 
 from ..plugin_setup import plugin
 

--- a/q2_types/per_sample_sequences/_transformer.py
+++ b/q2_types/per_sample_sequences/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/per_sample_sequences/_transformer.py
+++ b/q2_types/per_sample_sequences/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/per_sample_sequences/_type.py
+++ b/q2_types/per_sample_sequences/_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/per_sample_sequences/_type.py
+++ b/q2_types/per_sample_sequences/_type.py
@@ -1,12 +1,12 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime.plugin import SemanticType
+from qiime2.plugin import SemanticType
 
 from ..plugin_setup import plugin
 from ..sample_data import SampleData

--- a/q2_types/per_sample_sequences/tests/__init__.py
+++ b/q2_types/per_sample_sequences/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/per_sample_sequences/tests/__init__.py
+++ b/q2_types/per_sample_sequences/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/per_sample_sequences/tests/test_format.py
+++ b/q2_types/per_sample_sequences/tests/test_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/per_sample_sequences/tests/test_format.py
+++ b/q2_types/per_sample_sequences/tests/test_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -14,7 +14,7 @@ from q2_types.per_sample_sequences import (
     FastqManifestFormat, SingleLanePerSampleSingleEndFastqDirFmt,
     SingleLanePerSamplePairedEndFastqDirFmt
 )
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestFormats(TestPluginBase):

--- a/q2_types/per_sample_sequences/tests/test_transformer.py
+++ b/q2_types/per_sample_sequences/tests/test_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/per_sample_sequences/tests/test_transformer.py
+++ b/q2_types/per_sample_sequences/tests/test_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -16,7 +16,7 @@ from q2_types.per_sample_sequences import (
     SingleLanePerSamplePairedEndFastqDirFmt,
     CasavaOneEightSingleLanePerSampleDirFmt
 )
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestTransformers(TestPluginBase):

--- a/q2_types/per_sample_sequences/tests/test_type.py
+++ b/q2_types/per_sample_sequences/tests/test_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/per_sample_sequences/tests/test_type.py
+++ b/q2_types/per_sample_sequences/tests/test_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -15,7 +15,7 @@ from q2_types.per_sample_sequences import (
     SingleLanePerSampleSingleEndFastqDirFmt,
     SingleLanePerSamplePairedEndFastqDirFmt
 )
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestTypes(TestPluginBase):

--- a/q2_types/plugin_setup.py
+++ b/q2_types/plugin_setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/plugin_setup.py
+++ b/q2_types/plugin_setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -8,13 +8,13 @@
 
 import importlib
 
-import qiime.plugin
-import qiime.sdk
+import qiime2.plugin
+import qiime2.sdk
 
 from q2_types import __version__
 
 
-plugin = qiime.plugin.Plugin(
+plugin = qiime2.plugin.Plugin(
     name='types',
     version=__version__,
     website='https://github.com/qiime2/q2-types',

--- a/q2_types/reference_features/__init__.py
+++ b/q2_types/reference_features/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/reference_features/__init__.py
+++ b/q2_types/reference_features/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/reference_features/_format.py
+++ b/q2_types/reference_features/_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/reference_features/_format.py
+++ b/q2_types/reference_features/_format.py
@@ -1,12 +1,12 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import qiime.plugin.model as model
+import qiime2.plugin.model as model
 
 from ..feature_data import (DNAFASTAFormat, AlignedDNAFASTAFormat,
                             TaxonomyFormat)

--- a/q2_types/reference_features/_transformer.py
+++ b/q2_types/reference_features/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/reference_features/_transformer.py
+++ b/q2_types/reference_features/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/reference_features/_type.py
+++ b/q2_types/reference_features/_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/reference_features/_type.py
+++ b/q2_types/reference_features/_type.py
@@ -1,12 +1,12 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime.plugin import SemanticType
+from qiime2.plugin import SemanticType
 
 from ..plugin_setup import plugin
 from . import ReferenceFeaturesDirectoryFormat

--- a/q2_types/reference_features/tests/__init__.py
+++ b/q2_types/reference_features/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/reference_features/tests/__init__.py
+++ b/q2_types/reference_features/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/reference_features/tests/test_format.py
+++ b/q2_types/reference_features/tests/test_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/reference_features/tests/test_format.py
+++ b/q2_types/reference_features/tests/test_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,7 +10,7 @@ import shutil
 import unittest
 
 from q2_types.reference_features import ReferenceFeaturesDirectoryFormat
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestFormats(TestPluginBase):

--- a/q2_types/reference_features/tests/test_type.py
+++ b/q2_types/reference_features/tests/test_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/reference_features/tests/test_type.py
+++ b/q2_types/reference_features/tests/test_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,7 +10,7 @@ import unittest
 
 from q2_types.reference_features import (ReferenceFeaturesDirectoryFormat,
                                          ReferenceFeatures, SSU)
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestTypes(TestPluginBase):

--- a/q2_types/sample_data/__init__.py
+++ b/q2_types/sample_data/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/sample_data/__init__.py
+++ b/q2_types/sample_data/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/sample_data/_format.py
+++ b/q2_types/sample_data/_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/sample_data/_format.py
+++ b/q2_types/sample_data/_format.py
@@ -1,12 +1,12 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import qiime.plugin.model as model
+import qiime2.plugin.model as model
 
 from ..plugin_setup import plugin
 

--- a/q2_types/sample_data/_transformer.py
+++ b/q2_types/sample_data/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/sample_data/_transformer.py
+++ b/q2_types/sample_data/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/sample_data/_type.py
+++ b/q2_types/sample_data/_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/sample_data/_type.py
+++ b/q2_types/sample_data/_type.py
@@ -1,12 +1,12 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime.plugin import SemanticType
+from qiime2.plugin import SemanticType
 
 from ..plugin_setup import plugin
 from . import AlphaDiversityDirectoryFormat

--- a/q2_types/sample_data/tests/__init__.py
+++ b/q2_types/sample_data/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/sample_data/tests/__init__.py
+++ b/q2_types/sample_data/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/sample_data/tests/test_format.py
+++ b/q2_types/sample_data/tests/test_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/sample_data/tests/test_format.py
+++ b/q2_types/sample_data/tests/test_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -11,7 +11,7 @@ import unittest
 
 from q2_types.sample_data import (AlphaDiversityDirectoryFormat,
                                   AlphaDiversityFormat)
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestFormats(TestPluginBase):

--- a/q2_types/sample_data/tests/test_transformer.py
+++ b/q2_types/sample_data/tests/test_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/sample_data/tests/test_transformer.py
+++ b/q2_types/sample_data/tests/test_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -12,7 +12,7 @@ import pandas as pd
 
 from pandas.util.testing import assert_series_equal
 from q2_types.sample_data import AlphaDiversityFormat
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestTransformers(TestPluginBase):

--- a/q2_types/sample_data/tests/test_type.py
+++ b/q2_types/sample_data/tests/test_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/sample_data/tests/test_type.py
+++ b/q2_types/sample_data/tests/test_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,7 +10,7 @@ import unittest
 
 from q2_types.sample_data import (AlphaDiversityDirectoryFormat,
                                   SampleData, AlphaDiversity)
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestTypes(TestPluginBase):

--- a/q2_types/tree/__init__.py
+++ b/q2_types/tree/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/tree/__init__.py
+++ b/q2_types/tree/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/tree/_format.py
+++ b/q2_types/tree/_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/tree/_format.py
+++ b/q2_types/tree/_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 import skbio.io
-import qiime.plugin.model as model
+import qiime2.plugin.model as model
 
 from ..plugin_setup import plugin
 

--- a/q2_types/tree/_transformer.py
+++ b/q2_types/tree/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/tree/_transformer.py
+++ b/q2_types/tree/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/tree/_type.py
+++ b/q2_types/tree/_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/tree/_type.py
+++ b/q2_types/tree/_type.py
@@ -1,12 +1,12 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime.plugin import SemanticType
+from qiime2.plugin import SemanticType
 
 from ..plugin_setup import plugin
 from . import NewickDirectoryFormat

--- a/q2_types/tree/tests/__init__.py
+++ b/q2_types/tree/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/tree/tests/__init__.py
+++ b/q2_types/tree/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/tree/tests/test_format.py
+++ b/q2_types/tree/tests/test_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/tree/tests/test_format.py
+++ b/q2_types/tree/tests/test_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,7 +10,7 @@ import shutil
 import unittest
 
 from q2_types.tree import NewickFormat, NewickDirectoryFormat
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestFormats(TestPluginBase):

--- a/q2_types/tree/tests/test_transformer.py
+++ b/q2_types/tree/tests/test_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/tree/tests/test_transformer.py
+++ b/q2_types/tree/tests/test_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -11,7 +11,7 @@ import unittest
 import skbio
 
 from q2_types.tree import NewickFormat
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestTransformers(TestPluginBase):

--- a/q2_types/tree/tests/test_type.py
+++ b/q2_types/tree/tests/test_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_types/tree/tests/test_type.py
+++ b/q2_types/tree/tests/test_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -9,7 +9,7 @@
 import unittest
 
 from q2_types.tree import Phylogeny, Rooted, Unrooted, NewickDirectoryFormat
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class TestTypes(TestPluginBase):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME 2 development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016--, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,19 +10,18 @@ from setuptools import setup, find_packages
 
 setup(
     name="q2-types",
-    # TODO stop duplicating version string
-    version="0.0.7.dev0",
+    version="2017.2.0.dev0",
     packages=find_packages(),
-    install_requires=['scikit-bio', 'qiime >= 2.0.6', 'pandas',
+    install_requires=['scikit-bio', 'qiime2 == 2017.2.*', 'pandas',
                       'biom-format >= 2.1.5, < 2.2.0', 'ijson',
                       'h5py'],
     author="Greg Caporaso",
     author_email="gregcaporaso@gmail.com",
     description="Common QIIME 2 semantic types.",
     license='BSD-3-Clause',
-    url="http://www.qiime.org",
+    url="https://qiime2.org",
     entry_points={
-        'qiime.plugins':
+        'qiime2.plugins':
         ['q2-types=q2_types.plugin_setup:plugin']
     },
     package_data={


### PR DESCRIPTION
# ~~DO NOT MERGE (DONT EVEN LOOK AT ME!)~~

## ~~NOTE TO REVIEWER: please "rebase and merge," this PR contains standalone logical commits~~

New date-based versioning scheme is:

- YYYY.M.patch.dev0 for development version (e.g. 2017.2.0.dev0, 2017.2.1.dev0, 2018.10.0.dev0)
- YYYY.M.patch for release version (e.g. 2017.2.0, 2017.2.1, 2018.10.0)

Plugins/interfaces are recommended to specify `qiime2 == YYYY.M.*` in setup.py's `install_requires` to obtain patch releases for a given train release.

The new versioning scheme is PEP 440 compliant.