### PR TITLE
ENH: Adding in hierarchy type

### DIFF
--- a/q2_types/tree/__init__.py
+++ b/q2_types/tree/__init__.py
@@ -9,9 +9,10 @@
 import importlib
 
 from ._format import NewickFormat, NewickDirectoryFormat
-from ._type import Phylogeny, Rooted, Unrooted
+from ._type import Phylogeny, Rooted, Unrooted, Hierarchy
 
 __all__ = [
-    'NewickFormat', 'NewickDirectoryFormat', 'Phylogeny', 'Rooted', 'Unrooted']
+    'NewickFormat', 'NewickDirectoryFormat', 'Phylogeny',
+    'Rooted', 'Unrooted', 'Hierarchy']
 
 importlib.import_module('q2_types.tree._transformer')

--- a/q2_types/tree/_type.py
+++ b/q2_types/tree/_type.py
@@ -18,7 +18,12 @@ Rooted = SemanticType('Rooted', variant_of=Phylogeny.field['type'])
 
 Unrooted = SemanticType('Unrooted', variant_of=Phylogeny.field['type'])
 
-plugin.register_semantic_types(Phylogeny, Rooted, Unrooted)
+Hierarchy = SemanticType('Hierarchy')
+
+plugin.register_semantic_types(Phylogeny, Rooted, Unrooted, Hierarchy)
 
 plugin.register_semantic_type_to_format(Phylogeny[Rooted | Unrooted],
+                                        artifact_format=NewickDirectoryFormat)
+
+plugin.register_semantic_type_to_format(Hierarchy,
                                         artifact_format=NewickDirectoryFormat)

--- a/q2_types/tree/tests/test_type.py
+++ b/q2_types/tree/tests/test_type.py
@@ -8,7 +8,8 @@
 
 import unittest
 
-from q2_types.tree import Phylogeny, Rooted, Unrooted, NewickDirectoryFormat
+from q2_types.tree import (Phylogeny, Rooted, Unrooted,
+                           Hierarchy, NewickDirectoryFormat)
 from qiime2.plugin.testing import TestPluginBase
 
 
@@ -24,9 +25,16 @@ class TestTypes(TestPluginBase):
     def test_unrooted_semantic_type_registration(self):
         self.assertRegisteredSemanticType(Unrooted)
 
+    def test_phylogeny_semantic_type_registration(self):
+        self.assertRegisteredSemanticType(Hierarchy)
+
     def test_phylogeny_rooted_unrooted_to_newick_dir_fmt_registration(self):
         self.assertSemanticTypeRegisteredToFormat(
             Phylogeny[Rooted | Unrooted], NewickDirectoryFormat)
+
+    def test_phylogeny_rooted_unrooted_to_newick_dir_fmt_registration(self):
+        self.assertSemanticTypeRegisteredToFormat(
+            Hierarchy, NewickDirectoryFormat)
 
 
 if __name__ == '__main__':

--- a/q2_types/tree/tests/test_type.py
+++ b/q2_types/tree/tests/test_type.py
@@ -25,14 +25,14 @@ class TestTypes(TestPluginBase):
     def test_unrooted_semantic_type_registration(self):
         self.assertRegisteredSemanticType(Unrooted)
 
-    def test_phylogeny_semantic_type_registration(self):
+    def test_hierarchy_semantic_type_registration(self):
         self.assertRegisteredSemanticType(Hierarchy)
 
     def test_phylogeny_rooted_unrooted_to_newick_dir_fmt_registration(self):
         self.assertSemanticTypeRegisteredToFormat(
             Phylogeny[Rooted | Unrooted], NewickDirectoryFormat)
 
-    def test_phylogeny_rooted_unrooted_to_newick_dir_fmt_registration(self):
+    def test_hierarchy_to_newick_dir_fmt_registration(self):
         self.assertSemanticTypeRegisteredToFormat(
             Hierarchy, NewickDirectoryFormat)
 


### PR DESCRIPTION
This pull request is for introducing another tree data type `Hierarchy`.

The main motivation behind this is there are other instances of trees other than `Phylogeny` such as  hierarchical clusterings.  And using `Phylogeny` to represent these data types are incredibly misleading.  This is critical for reducing confusion for performing analyses with Gneiss, which can operate directly on `Phylogeny` and `Hierarchy` types.