### PR TITLE
BUG: Handle MANIFEST comments in per sample transformer

### DIFF
--- a/q2_types/per_sample_sequences/_transformer.py
+++ b/q2_types/per_sample_sequences/_transformer.py
@@ -45,7 +45,10 @@ class PerSamplePairedDNAIterators(dict):
 
 
 def _iterator_magic(filepath):
-    yield from skbio.io.read(filepath, format='fastq', constructor=skbio.DNA)
+    def sequence_generator():
+        yield from skbio.io.read(filepath, format='fastq',
+                                 constructor=skbio.DNA)
+    return sequence_generator
 
 
 def _prepare_manifest(dirfmt):
@@ -53,8 +56,7 @@ def _prepare_manifest(dirfmt):
                            header=0, comment='#').set_index('sample-id')
     manifest.filename = manifest.filename.apply(lambda x: str(dirfmt.path / x))
 
-    manifest['data'] = manifest.filename.apply(
-        lambda filepath: lambda: _iterator_magic(filepath))
+    manifest['data'] = manifest.filename.apply(_iterator_magic)
 
     return manifest
 

--- a/q2_types/per_sample_sequences/_transformer.py
+++ b/q2_types/per_sample_sequences/_transformer.py
@@ -43,6 +43,7 @@ def _prepare_manifest(dirfmt):
 
     return manifest
 
+
 # Transformers
 @plugin.register_transformer
 def _1(dirfmt: SingleLanePerSampleSingleEndFastqDirFmt) \

--- a/q2_types/per_sample_sequences/_transformer.py
+++ b/q2_types/per_sample_sequences/_transformer.py
@@ -29,9 +29,9 @@ class PerSampleDNAIterators(dict):
     def __getitem__(self, key):
         return super().__getitem__(key)()
 
-    def items(self):
-        for key, value in super().items():
-            yield (key, value())
+    def __iter__(self):
+        for sample_id, seqs in self.items():
+            yield sample_id, seqs()
 
 
 class PerSamplePairedDNAIterators(dict):
@@ -39,9 +39,9 @@ class PerSamplePairedDNAIterators(dict):
         fwd, rev = super().__getitem__(key)
         return fwd(), rev()
 
-    def items(self):
-        for key, (fwd, rev) in super().items():
-            yield (key, (fwd(), rev()))
+    def __iter__(self):
+        for sample_id, (fwd, rev) in self.items():
+            yield sample_id, (fwd(), rev())
 
 
 def _iterator_magic(filepath):


### PR DESCRIPTION
This resolves comments in the `MANIFEST` file, ~~but runs into the same issue that demultiplexing did, where it hits the open file limit on large sample sets.~~

Resolves #129 

