### PR TITLE
BUG: remove PerSampleDNAIterators and PerSamplePairedDNAIterators

### DIFF
--- a/q2_types/per_sample_sequences/__init__.py
+++ b/q2_types/per_sample_sequences/__init__.py
@@ -19,7 +19,6 @@ from ._format import (CasavaOneEightSingleLanePerSampleDirFmt,
                       PairedEndFastqManifestPhred33,
                       PairedEndFastqManifestPhred64)
 from ._type import SequencesWithQuality, PairedEndSequencesWithQuality
-from ._transformer import PerSampleDNAIterators, PerSamplePairedDNAIterators
 
 __all__ = ['CasavaOneEightSingleLanePerSampleDirFmt',
            'CasavaOneEightLanelessPerSampleDirFmt',
@@ -27,8 +26,7 @@ __all__ = ['CasavaOneEightSingleLanePerSampleDirFmt',
            'FastqAbsolutePathManifestFormat',
            'SingleLanePerSampleSingleEndFastqDirFmt',
            'SingleLanePerSamplePairedEndFastqDirFmt', 'SequencesWithQuality',
-           'PairedEndSequencesWithQuality', 'PerSampleDNAIterators',
-           'PerSamplePairedDNAIterators', 'SingleEndFastqManifestPhred33',
+           'PairedEndSequencesWithQuality', 'SingleEndFastqManifestPhred33',
            'SingleEndFastqManifestPhred64', 'PairedEndFastqManifestPhred33',
            'PairedEndFastqManifestPhred64']
 

--- a/q2_types/per_sample_sequences/tests/test_transformer.py
+++ b/q2_types/per_sample_sequences/tests/test_transformer.py
@@ -16,7 +16,6 @@ import yaml
 import pandas as pd
 
 from q2_types.per_sample_sequences import (
-    PerSampleDNAIterators, PerSamplePairedDNAIterators,
     SingleLanePerSampleSingleEndFastqDirFmt,
     SingleLanePerSamplePairedEndFastqDirFmt,
     CasavaOneEightSingleLanePerSampleDirFmt,
@@ -36,47 +35,6 @@ from qiime2.plugin.testing import TestPluginBase
 
 class TestTransformers(TestPluginBase):
     package = "q2_types.per_sample_sequences.tests"
-
-    def test_slpssefdf_to_per_sample_dna_iterators(self):
-        filenames = ('single_end_data/MANIFEST', 'metadata.yml',
-                     'Human-Kneecap_S1_L001_R1_001.fastq.gz')
-        input, obs = self.transform_format(
-            SingleLanePerSampleSingleEndFastqDirFmt, PerSampleDNAIterators,
-            filenames=filenames
-        )
-
-        obs = obs['Human-Kneecap']
-        sk = skbio.io.read(
-            '%s/Human-Kneecap_S1_L001_R1_001.fastq.gz' % str(input),
-            format='fastq', constructor=skbio.DNA
-        )
-
-        for act, exp in zip(obs, sk):
-            self.assertEqual(act, exp)
-
-    def test_slpspefdf_to_per_sample_paired_dna_iterators(self):
-        filenames = ('paired_end_data/MANIFEST', 'metadata.yml',
-                     'Human-Kneecap_S1_L001_R1_001.fastq.gz',
-                     'paired_end_data/Human-Kneecap_S1_L001_R2_001.fastq.gz')
-        input, obs = self.transform_format(
-            SingleLanePerSamplePairedEndFastqDirFmt,
-            PerSamplePairedDNAIterators, filenames=filenames
-        )
-
-        obs = obs['Human-Kneecap']
-        sk1 = skbio.io.read(
-            '%s/Human-Kneecap_S1_L001_R1_001.fastq.gz' % str(input),
-            format='fastq', constructor=skbio.DNA
-        )
-        sk2 = skbio.io.read(
-            '%s/Human-Kneecap_S1_L001_R2_001.fastq.gz' % str(input),
-            format='fastq', constructor=skbio.DNA
-        )
-        expected = sk1, sk2
-
-        for act, exp in zip(obs, expected):
-            for seq1, seq2 in zip(act, exp):
-                self.assertEqual(seq1, seq2)
 
     def test_slpspefdf_to_slpssefdf(self):
         filenames = ('paired_end_data/MANIFEST', 'metadata.yml',


### PR DESCRIPTION
Removes `q2_types.per_sample_sequences.PerSampleDNAIterators` and `q2_types.per_sample_sequences.PerSamplePairedDNAIterators` view types, along with their corresponding transformers. As part of discussion in #129 and #130 it was found that these view types never actually worked and weren't being used anywhere. Even getting them to work raises another problem: file descriptor limit.

New view types can be added in the future that avoid the file descriptor limit.