### PR TITLE
HACK: allow empty fasta files

### DIFF
--- a/q2_types/feature_data/_format.py
+++ b/q2_types/feature_data/_format.py
@@ -144,7 +144,10 @@ class DNAFASTAFormat(model.TextFileFormat):
             # ValueError raised by skbio if there are invalid DNA chars.
             except ValueError:
                 pass
-        return False
+
+        # Empty files are ok also
+        empty_sniffer = skbio.io.io_registry.get_sniffer('<emptyfile>')
+        return empty_sniffer(filepath)[0]
 
 
 DNASequencesDirectoryFormat = model.SingleFileDirectoryFormat(

--- a/q2_types/feature_data/tests/test_format.py
+++ b/q2_types/feature_data/tests/test_format.py
@@ -151,6 +151,14 @@ class TestDNAFASTAFormats(TestPluginBase):
         with self.assertRaisesRegex(ValidationError, 'DNAFASTA'):
             format._validate_()
 
+    def test_dna_fasta_format_empty_file(self):
+        filepath = os.path.join(self.temp_dir.name, 'empty')
+        with open(filepath, 'w') as fh:
+            fh.write('\n')
+        format = DNAFASTAFormat(filepath, mode='r')
+
+        format._validate_()
+
     def test_dna_sequences_directory_format(self):
         filepath = self.get_data_path('dna-sequences.fasta')
         shutil.copy(filepath,


### PR DESCRIPTION
We didn't turn this into a validate because fasta is a much more flexible format so it didn't seem worth the time at this point.