### PR TITLE
ENH: support empty files in QIIME1DemuxFormat

### DIFF
--- a/q2_types/per_sample_sequences/_format.py
+++ b/q2_types/per_sample_sequences/_format.py
@@ -310,10 +310,6 @@ class QIIME1DemuxFormat(model.TextFileFormat):
 
             ids.add(id)
 
-        if not ids:
-            # File was empty.
-            raise Exception()
-
     def _parse_id(self, header):
         if not header.startswith('>'):
             raise Exception()

--- a/q2_types/per_sample_sequences/tests/test_format.py
+++ b/q2_types/per_sample_sequences/tests/test_format.py
@@ -344,11 +344,11 @@ class TestQIIME1DemuxFormat(TestPluginBase):
         super().setUp()
 
         self.positives = [
-            'short.fna', 'long.fna', 'single-record.fna',
+            'empty', 'short.fna', 'long.fna', 'single-record.fna',
             'with-descriptions.fna', 'split-libraries-output.fna'
         ]
         self.negatives = [
-            'empty', 'incomplete.fna', 'empty-header.fna',
+            'incomplete.fna', 'empty-header.fna',
             'invalid-header.fna', 'description-only.fna', 'blank-line.fna',
             'no-underscore-in-id.fna', 'no-sample-id.fna',
             'no-secondary-id.fna', 'duplicate-ids.fna', 'empty-seq.fna',


### PR DESCRIPTION
This change is necessary to support the closed-reference OTU picking API in q2-ninja-ops, which returns a QIIME1DemuxFormat file of sequences that failed to hit the reference. It is possible in some cases for there to be zero failures.

This change is similar to allowing empty `FeatureData[Sequence]` artifacts, which is required by q2-vsearch's closed-reference OTU picking API.