### PR TITLE
Add PercentileNormalized type declaration

### DIFF
--- a/q2_types/feature_table/_type.py
+++ b/q2_types/feature_table/_type.py
@@ -28,11 +28,16 @@ Composition = SemanticType('Composition',
 Balance = SemanticType('Balance',
                        variant_of=FeatureTable.field['content'])
 
+PercentileNormalized = SemanticType('PercentileNormalized',
+                                     variant_of=FeatureTable.field['content'])
+
 plugin.register_semantic_types(FeatureTable, Frequency, RelativeFrequency,
-                               PresenceAbsence, Balance, Composition)
+                               PresenceAbsence, Balance, Composition,
+                               PercentileNormalized)
 
 plugin.register_semantic_type_to_format(
     FeatureTable[Frequency | RelativeFrequency |
-                 PresenceAbsence | Balance | Composition],
+                 PresenceAbsence | Balance | Composition |
+                 PercentileNormalized],
     artifact_format=BIOMV210DirFmt
 )


### PR DESCRIPTION
I moved the PercentileNormalized data type declaration from my [q2-perc-norm](https://github.com/cduvallet/q2-perc-norm) `plugin_setup.py` to the `q2-types` module.