### PR TITLE
Bump the scikit-bio version to 0.5.4 (containing new pcoa api)

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   run:
     - python 3.5*
     - setuptools
-    - scikit-bio >=0.5.3
+    - scikit-bio >=0.5.4
     - pandas
     - biom-format >=2.1.5,<2.2.0
     - ijson


### PR DESCRIPTION
This bumps skbio to 0.5.4 (which has not been released yet but will be within a day or so).

Skbio 0.5.4 is needed to support: https://github.com/qiime2/q2-diversity/pull/217, which
updates the ordination class in `q2-diversity` to support new scikit-bio's fast heuristic pcoa method.

TO-DO:

- [x] 1. Wait until skbio is bumped to 0.5.3 in qiime 2: https://github.com/qiime2/q2-types/pull/191
- [x] 2. Wait until scikit-bio 0.5.4 is released, which incorporates the new pcoa/fsvd PR https://github.com/biocore/scikit-bio/pull/1569