### PR TITLE
ENH: multi-column alpha diversity as metadata

### DIFF
--- a/q2_types/sample_data/tests/test_transformer.py
+++ b/q2_types/sample_data/tests/test_transformer.py
@@ -72,7 +72,7 @@ class TestTransformers(TestPluginBase):
 
     def test_non_alpha_diversity(self):
         filename = 'also-not-alpha-diversity.tsv'
-        with self.assertRaisesRegex(ValueError, 'Unable to parse string'):
+        with self.assertRaisesRegex(ValueError, 'Non-numeric values '):
             self.transform_format(AlphaDiversityFormat, pd.Series, filename)
 
 


### PR DESCRIPTION
AlphaDiversityFormat to Metadata transformer now supports multi-column alpha diversity data. Previously only the first data column would be included when viewed as Metadata. 

For example, `qiime metadata tabulate --m-input-file richness-better.qza --o-visualization richness-better.qzv` before:

<img width="1188" alt="screenshot 2018-08-28 15 54 14" src="https://user-images.githubusercontent.com/192372/44755364-c2a53700-aada-11e8-8fc5-aaa71a89766c.png">

and after:
<img width="1179" alt="screenshot 2018-08-28 15 54 27" src="https://user-images.githubusercontent.com/192372/44755378-c89b1800-aada-11e8-8332-6346eaf3b5dc.png">

