### PR TITLE
Update for flake8 v3.6

### DIFF
--- a/q2_types/per_sample_sequences/_transformer.py
+++ b/q2_types/per_sample_sequences/_transformer.py
@@ -360,7 +360,7 @@ def _12(dirfmt: SingleLanePerSampleSingleEndFastqDirFmt) \
         for r in input_manifest.iterrows():
             sample_id = r[1]['sample-id']
             filename = r[1]['filename']
-            if re.search("\s", sample_id) is not None:
+            if re.search(r"\s", sample_id) is not None:
                 raise ValueError(
                     "Whitespace was found in the ID for sample %s. Sample "
                     "IDs with whitespace are incompatible with FASTA."

--- a/q2_types/per_sample_sequences/tests/test_format.py
+++ b/q2_types/per_sample_sequences/tests/test_format.py
@@ -393,7 +393,7 @@ class TestQIIME1DemuxFormat(TestPluginBase):
         shutil.copy(filepath, self.temp_dir.name)
 
         with self.assertRaisesRegex(ValidationError,
-                                    'QIIME1DemuxDirFmt.*seqs\.fna'):
+                                    r'QIIME1DemuxDirFmt.*seqs\.fna'):
             QIIME1DemuxDirFmt(self.temp_dir.name, mode='r').validate()
 
 

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,5 +1,6 @@
 
 # Version: 0.18
+# flake8: noqa
 
 """The Versioneer - like a rocketeer, but for versions.
 


### PR DESCRIPTION
Minor updates for compliance with flake8 v3.6, as discussed in qiime2/qiime2#415
Note: flake8 has been disabled in versioneer.py.