### PR TITLE
HACK: Pin scipy to older version

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   run:
     - python {{ python }}
     - scikit-bio >=0.5.4
+    - scipy >=1.0.0,<1.3.0
     - numpy
     - blas=*=openblas
     # AVX 512 extensions are broken in 0.3.5 and 0.3.6


### PR DESCRIPTION
closes #215: Pin `scipy` to >=1.0.0,<1.3.0 to prevent import bug in `statsmodels`