### PR TITLE
Revert "HACK: Pin scipy to older version"

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -19,7 +19,6 @@ requirements:
   run:
     - python {{ python }}
     - scikit-bio >=0.5.4
-    - scipy >=1.0.0,<1.3.0
     - numpy
     - blas=*=openblas
     # AVX 512 extensions are broken in 0.3.5 and 0.3.6


### PR DESCRIPTION
Reverts qiime2/q2-types#216

Statsmodels has finally been released!