### PR TITLE
Revert "BUG: pin OpenBLAS for SkylakeX+ processors (#213)"

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -21,8 +21,6 @@ requirements:
     - scikit-bio >=0.5.4
     - numpy
     - blas=*=openblas
-    # AVX 512 extensions are broken in 0.3.5 and 0.3.6
-    - openblas 0.3.3
     - pandas
     - biom-format >=2.1.5,<2.2.0
     - ijson


### PR DESCRIPTION
Recent OpenBLAS versions have fixed the AVX situation, so unpin.

https://github.com/conda-forge/openblas-feedstock/issues/64
https://github.com/xianyi/OpenBLAS/pull/2111