### PR TITLE
MAINT: removed use of deprecated method from_csv

### DIFF
--- a/q2_types/sample_data/tests/test_transformer.py
+++ b/q2_types/sample_data/tests/test_transformer.py
@@ -26,6 +26,10 @@ class TestTransformers(TestPluginBase):
                         name='shannon', index=exp_index)
 
         obs = transformer(exp)
+        '''
+        Squeeze equals true in function call below to convert single column
+        dataframe to series
+        '''
         obs = pd.read_csv(str(obs), sep='\t', header=0, index_col=0,
                           squeeze=True)
 

--- a/q2_types/sample_data/tests/test_transformer.py
+++ b/q2_types/sample_data/tests/test_transformer.py
@@ -26,8 +26,8 @@ class TestTransformers(TestPluginBase):
                         name='shannon', index=exp_index)
 
         obs = transformer(exp)
-        obs = pd.read_csv(str(obs), sep='\t', parse_dates=True, header=0,
-                          index_col=0, squeeze=True)
+        obs = pd.read_csv(str(obs), sep='\t', header=0, index_col=0,
+                          squeeze=True)
 
         assert_series_equal(exp, obs)
 

--- a/q2_types/sample_data/tests/test_transformer.py
+++ b/q2_types/sample_data/tests/test_transformer.py
@@ -27,8 +27,7 @@ class TestTransformers(TestPluginBase):
 
         obs = transformer(exp)
 
-        # Squeeze equals true in function call below to return series instead
-        # of dataframe
+        # Squeeze equals true to return series instead of dataframe
         obs = pd.read_csv(str(obs), sep='\t', header=0, index_col=0,
                           squeeze=True)
 

--- a/q2_types/sample_data/tests/test_transformer.py
+++ b/q2_types/sample_data/tests/test_transformer.py
@@ -26,7 +26,8 @@ class TestTransformers(TestPluginBase):
                         name='shannon', index=exp_index)
 
         obs = transformer(exp)
-        obs = pd.Series.from_csv(str(obs), sep='\t', header=0)
+        obs = pd.read_csv(str(obs), sep='\t', parse_dates=True, header=0, 
+                          index_col=0, squeeze=True)
 
         assert_series_equal(exp, obs)
 

--- a/q2_types/sample_data/tests/test_transformer.py
+++ b/q2_types/sample_data/tests/test_transformer.py
@@ -26,7 +26,7 @@ class TestTransformers(TestPluginBase):
                         name='shannon', index=exp_index)
 
         obs = transformer(exp)
-        obs = pd.read_csv(str(obs), sep='\t', parse_dates=True, header=0, 
+        obs = pd.read_csv(str(obs), sep='\t', parse_dates=True, header=0,
                           index_col=0, squeeze=True)
 
         assert_series_equal(exp, obs)

--- a/q2_types/sample_data/tests/test_transformer.py
+++ b/q2_types/sample_data/tests/test_transformer.py
@@ -26,10 +26,9 @@ class TestTransformers(TestPluginBase):
                         name='shannon', index=exp_index)
 
         obs = transformer(exp)
-        '''
-        Squeeze equals true in function call below to convert single column
-        dataframe to series
-        '''
+
+        # Squeeze equals true in function call below to return series instead
+        # of dataframe
         obs = pd.read_csv(str(obs), sep='\t', header=0, index_col=0,
                           squeeze=True)
 


### PR DESCRIPTION
Pandas has deprecated the `from_csv` method in favor of `read_csv` as of `v0.21.0`. This change is needed to make plugins pass unit tests utilizing the newest version of pandas `v0.25.1`. Fixes issue #227 