### PR TITLE
HACK: hard pins matplotlib at 3.1.0

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -25,6 +25,8 @@ requirements:
     - biom-format >=2.1.5,<2.2.0
     - ijson
     - h5py
+    - matplotlib=3.1.0
+    - matplotlib-base=3.1.0
     - qiime2 {{ release }}.*
 
 test:

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -25,8 +25,8 @@ requirements:
     - biom-format >=2.1.5,<2.2.0
     - ijson
     - h5py
-    - matplotlib=3.1.0
-    - matplotlib-base=3.1.0
+    - matplotlib 3.1.0
+    - matplotlib-base 3.1.0
     - qiime2 {{ release }}.*
 
 test:


### PR DESCRIPTION
fixes qiime2/q2-sample-classifier#164
we'll want to [open this pin up to future versions](https://github.com/qiime2/q2-types/issues/232) in 2020.1