### PR TITLE
MAINT: Improve error message for invalid characters in DNAFASTAFormat

### DIFF
--- a/q2_types/feature_data/_format.py
+++ b/q2_types/feature_data/_format.py
@@ -146,6 +146,9 @@ TSVTaxonomyDirectoryFormat = model.SingleFileDirectoryFormat(
 class DNAFASTAFormat(model.TextFileFormat):
     def _validate_lines(self, max_lines):
         FASTADNAValidator = re.compile(r'[ACGTURYKMSWBDHVN]+\r?\n?')
+        ValidationSet = frozenset(('A', 'C', 'G', 'T', 'U', 'R', 'Y', 'K', 'M',
+                                   'S', 'W', 'B', 'D', 'H', 'V', 'N'))
+
         last_line_was_ID = False
         ids = {}
 
@@ -190,10 +193,12 @@ class DNAFASTAFormat(model.TextFileFormat):
                     elif re.fullmatch(FASTADNAValidator, line):
                         last_line_was_ID = False
                     else:
-                        raise ValidationError('Invalid characters on line '
-                                              f'{line_number} (does not match '
-                                              'IUPAC characters for a DNA '
-                                              'sequence).')
+                        for character in line:
+                            if character not in ValidationSet:
+                                raise ValidationError(
+                                    f"Invalid character '{character}' on line "
+                                    f"{line_number} (does not match IUPAC "
+                                    "characters for a DNA sequence).")
             except UnicodeDecodeError as e:
                 raise ValidationError(f'utf-8 cannot decode byte on line '
                                       f'{line_number}') from e

--- a/q2_types/feature_data/_format.py
+++ b/q2_types/feature_data/_format.py
@@ -193,10 +193,11 @@ class DNAFASTAFormat(model.TextFileFormat):
                     elif re.fullmatch(FASTADNAValidator, line):
                         last_line_was_ID = False
                     else:
-                        for character in line:
+                        for position, character in enumerate(line):
                             if character not in ValidationSet:
                                 raise ValidationError(
-                                    f"Invalid character '{character}' on line "
+                                    f"Invalid character '{character}' at "
+                                    f"position {position} on line "
                                     f"{line_number} (does not match IUPAC "
                                     "characters for a DNA sequence).")
             except UnicodeDecodeError as e:

--- a/q2_types/feature_data/tests/data/not-dna-sequences.fasta
+++ b/q2_types/feature_data/tests/data/not-dna-sequences.fasta
@@ -1,0 +1,5 @@
+>DNA
+123456789
+
+>DNA
+abcdefghi

--- a/q2_types/feature_data/tests/test_format.py
+++ b/q2_types/feature_data/tests/test_format.py
@@ -176,7 +176,7 @@ class TestDNAFASTAFormats(TestPluginBase):
         format = DNAFASTAFormat(filepath, mode='r')
 
         with self.assertRaisesRegex(ValidationError, "Invalid character '1' "
-                                                     "on line 2"):
+                                                     ".*0 on line 2"):
             format.validate()
 
     def test_dna_fasta_format_validate_negative(self):

--- a/q2_types/feature_data/tests/test_format.py
+++ b/q2_types/feature_data/tests/test_format.py
@@ -171,6 +171,14 @@ class TestDNAFASTAFormats(TestPluginBase):
 
         format.validate()
 
+    def test_dna_fasta_format_invalid_characters(self):
+        filepath = self.get_data_path('not-dna-sequences.fasta')
+        format = DNAFASTAFormat(filepath, mode='r')
+
+        with self.assertRaisesRegex(ValidationError, "Invalid character '1' "
+                                                     "on line 2"):
+            format.validate()
+
     def test_dna_fasta_format_validate_negative(self):
         filepath = self.get_data_path('not-dna-sequences')
         format = DNAFASTAFormat(filepath, mode='r')


### PR DESCRIPTION
Implements the improvements discussed at the end of #214. Namely we now display to the user the first invalid character on the first invalid line.