### PR TITLE
HACK: Revert pin added in #233

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -25,8 +25,6 @@ requirements:
     - biom-format >=2.1.5,<2.2.0
     - ijson
     - h5py
-    - matplotlib 3.1.0
-    - matplotlib-base 3.1.0
     - qiime2 {{ release }}.*
 
 test:


### PR DESCRIPTION
closes #232, matplotlib 3.1.3 is producing correct heatmaps.
![Selection_026](https://user-images.githubusercontent.com/10642616/74460776-b0dc5e80-4e4a-11ea-8715-7a756735d071.png)
