### PR TITLE
BUG: Add test asserting that filenames are more fully regexed

### DIFF
--- a/q2_types/per_sample_sequences/tests/data/metadata.yml.txt
+++ b/q2_types/per_sample_sequences/tests/data/metadata.yml.txt
@@ -1,0 +1,1 @@
+{phred-offset: 33}

--- a/q2_types/per_sample_sequences/tests/data/single_end_data/MANIFEST.txt
+++ b/q2_types/per_sample_sequences/tests/data/single_end_data/MANIFEST.txt
@@ -1,0 +1,4 @@
+# Compelling observation regarding knee-caps
+
+sample-id,filename,direction
+Human-Kneecap,Human-Kneecap_S1_L001_R1_001.fastq.gz,forward

--- a/q2_types/per_sample_sequences/tests/test_format.py
+++ b/q2_types/per_sample_sequences/tests/test_format.py
@@ -515,6 +515,21 @@ class TestFormats(TestPluginBase):
                                     'paired'):
             format.validate()
 
+    def test_slanepsample_paired_end_fastq_dir_fmt_incorrect_filenames(self):
+        filenames = ('single_end_data/MANIFEST.txt', 'metadata.yml.txt',
+                     'Human-Kneecap_S1_L001_R1_001.fastq.gz',
+                     'paired_end_data/Human-Kneecap_S1_L001_R2_001.fastq.gz')
+        for filename in filenames:
+            filepath = self.get_data_path(filename)
+            shutil.copy(filepath, self.temp_dir.name)
+
+        format = SingleLanePerSamplePairedEndFastqDirFmt(
+            self.temp_dir.name, mode='r')
+
+        with self.assertRaisesRegex(ValidationError,
+                                    'Missing one or more files.*MANIFEST'):
+            format.validate()
+
 
 class TestQIIME1DemuxFormat(TestPluginBase):
     package = 'q2_types.per_sample_sequences.tests'


### PR DESCRIPTION
Adds a test for the behavior described in #218. I made sure the test will work properly when and if qiime2/qiime2#538 is merged.