### PR TITLE
maint: cleanup fasta exports and registrations

### DIFF
--- a/q2_types/feature_data/__init__.py
+++ b/q2_types/feature_data/__init__.py
@@ -14,7 +14,7 @@ from ._format import (
     TSVTaxonomyDirectoryFormat, DNAFASTAFormat, DNASequencesDirectoryFormat,
     PairedDNASequencesDirectoryFormat, AlignedDNAFASTAFormat,
     AlignedDNASequencesDirectoryFormat, DifferentialFormat,
-    DifferentialDirectoryFormat, FASTAFormat)
+    DifferentialDirectoryFormat, FASTAFormat, AlignedFASTAFormatMixin)
 from ._type import (
     FeatureData, Taxonomy, Sequence, PairedEndSequence, AlignedSequence,
     Differential)
@@ -30,6 +30,7 @@ __all__ = [
     'AlignedDNAFASTAFormat', 'AlignedDNASequencesDirectoryFormat',
     'FeatureData', 'Taxonomy', 'Sequence', 'PairedEndSequence',
     'AlignedSequence', 'DNAIterator', 'PairedDNAIterator', 'FASTAFormat',
-    'AlignedDNAIterator', 'Differential', 'DifferentialDirectoryFormat']
+    'AlignedDNAIterator', 'Differential', 'DifferentialDirectoryFormat',
+    'AlignedFASTAFormatMixin']
 
 importlib.import_module('q2_types.feature_data._transformer')

--- a/q2_types/feature_data/_format.py
+++ b/q2_types/feature_data/_format.py
@@ -331,5 +331,5 @@ plugin.register_formats(
     TaxonomyFormat, TaxonomyDirectoryFormat, DNAFASTAFormat,
     DNASequencesDirectoryFormat, PairedDNASequencesDirectoryFormat,
     AlignedDNAFASTAFormat, AlignedDNASequencesDirectoryFormat,
-    DifferentialFormat, DifferentialDirectoryFormat, FASTAFormat
+    DifferentialFormat, DifferentialDirectoryFormat,
 )


### PR DESCRIPTION
@misialq - what do you think about exporting the `AlignedFASTAFormatMixin`? Also, I dropped the `FASTAFormat` from the plugin format registration hook, since at present we don't intend for any consumers to actually work with this base format directly.