### PR TITLE
updates to artifact class registration

### DIFF
--- a/q2_types/distance_matrix/_type.py
+++ b/q2_types/distance_matrix/_type.py
@@ -17,5 +17,5 @@ DistanceMatrix = SemanticType('DistanceMatrix')
 plugin.register_semantic_types(DistanceMatrix)
 plugin.register_semantic_type_to_format(
     DistanceMatrix,
-    artifact_format=DistanceMatrixDirectoryFormat
+    directory_format=DistanceMatrixDirectoryFormat
 )

--- a/q2_types/feature_data/_type.py
+++ b/q2_types/feature_data/_type.py
@@ -59,33 +59,33 @@ plugin.register_semantic_types(FeatureData, Taxonomy, Sequence,
 
 plugin.register_semantic_type_to_format(
     FeatureData[Taxonomy],
-    artifact_format=TSVTaxonomyDirectoryFormat)
+    directory_format=TSVTaxonomyDirectoryFormat)
 plugin.register_semantic_type_to_format(
     FeatureData[Sequence],
-    artifact_format=DNASequencesDirectoryFormat)
+    directory_format=DNASequencesDirectoryFormat)
 plugin.register_semantic_type_to_format(
     FeatureData[RNASequence],
-    artifact_format=RNASequencesDirectoryFormat)
+    directory_format=RNASequencesDirectoryFormat)
 plugin.register_semantic_type_to_format(
     FeatureData[PairedEndSequence],
-    artifact_format=PairedDNASequencesDirectoryFormat)
+    directory_format=PairedDNASequencesDirectoryFormat)
 plugin.register_semantic_type_to_format(
     FeatureData[PairedEndRNASequence],
-    artifact_format=PairedRNASequencesDirectoryFormat)
+    directory_format=PairedRNASequencesDirectoryFormat)
 plugin.register_semantic_type_to_format(
     FeatureData[AlignedSequence],
-    artifact_format=AlignedDNASequencesDirectoryFormat)
+    directory_format=AlignedDNASequencesDirectoryFormat)
 plugin.register_semantic_type_to_format(
     FeatureData[AlignedRNASequence],
-    artifact_format=AlignedRNASequencesDirectoryFormat)
+    directory_format=AlignedRNASequencesDirectoryFormat)
 plugin.register_semantic_type_to_format(
     FeatureData[Differential], DifferentialDirectoryFormat)
 plugin.register_semantic_type_to_format(
     FeatureData[ProteinSequence],
-    artifact_format=ProteinSequencesDirectoryFormat)
+    directory_format=ProteinSequencesDirectoryFormat)
 plugin.register_semantic_type_to_format(
     FeatureData[AlignedProteinSequence],
-    artifact_format=AlignedProteinSequencesDirectoryFormat)
+    directory_format=AlignedProteinSequencesDirectoryFormat)
 plugin.register_semantic_type_to_format(
     FeatureData[BLAST6],
-    artifact_format=BLAST6DirectoryFormat)
+    directory_format=BLAST6DirectoryFormat)

--- a/q2_types/feature_table/_type.py
+++ b/q2_types/feature_table/_type.py
@@ -43,5 +43,5 @@ plugin.register_semantic_type_to_format(
     FeatureTable[Frequency | RelativeFrequency |
                  PresenceAbsence | Balance | Composition |
                  PercentileNormalized | Design],
-    artifact_format=BIOMV210DirFmt
+    directory_format=BIOMV210DirFmt
 )

--- a/q2_types/feature_table/tests/test_type.py
+++ b/q2_types/feature_table/tests/test_type.py
@@ -38,9 +38,25 @@ class TestTypes(TestPluginBase):
 
     def test_feature_table_semantic_type_to_v210_format_registration(self):
         self.assertSemanticTypeRegisteredToFormat(
-            FeatureTable[Frequency | RelativeFrequency | PresenceAbsence |
-                         Composition | Balance | PercentileNormalized |
-                         Design],
+            FeatureTable[Frequency],
+            BIOMV210DirFmt)
+        self.assertSemanticTypeRegisteredToFormat(
+            FeatureTable[RelativeFrequency],
+            BIOMV210DirFmt)
+        self.assertSemanticTypeRegisteredToFormat(
+            FeatureTable[PresenceAbsence],
+            BIOMV210DirFmt)
+        self.assertSemanticTypeRegisteredToFormat(
+            FeatureTable[Composition],
+            BIOMV210DirFmt)
+        self.assertSemanticTypeRegisteredToFormat(
+            FeatureTable[Balance],
+            BIOMV210DirFmt)
+        self.assertSemanticTypeRegisteredToFormat(
+            FeatureTable[PercentileNormalized],
+            BIOMV210DirFmt)
+        self.assertSemanticTypeRegisteredToFormat(
+            FeatureTable[Design],
             BIOMV210DirFmt)
 
 

--- a/q2_types/multiplexed_sequences/_type.py
+++ b/q2_types/multiplexed_sequences/_type.py
@@ -23,9 +23,9 @@ plugin.register_semantic_types(MultiplexedSingleEndBarcodeInSequence,
 
 plugin.register_semantic_type_to_format(
     MultiplexedSingleEndBarcodeInSequence,
-    artifact_format=MultiplexedSingleEndBarcodeInSequenceDirFmt
+    directory_format=MultiplexedSingleEndBarcodeInSequenceDirFmt
 )
 plugin.register_semantic_type_to_format(
     MultiplexedPairedEndBarcodeInSequence,
-    artifact_format=MultiplexedPairedEndBarcodeInSequenceDirFmt,
+    directory_format=MultiplexedPairedEndBarcodeInSequenceDirFmt,
 )

--- a/q2_types/ordination/_type.py
+++ b/q2_types/ordination/_type.py
@@ -19,11 +19,11 @@ ProcrustesStatistics = SemanticType('ProcrustesStatistics')
 plugin.register_semantic_types(PCoAResults, ProcrustesStatistics)
 plugin.register_semantic_type_to_format(
     PCoAResults,
-    artifact_format=OrdinationDirectoryFormat
+    directory_format=OrdinationDirectoryFormat
 )
 
 plugin.register_semantic_type_to_format(
     ProcrustesStatistics,
 
-    artifact_format=ProcrustesStatisticsDirFmt
+    directory_format=ProcrustesStatisticsDirFmt
 )

--- a/q2_types/per_sample_sequences/_type.py
+++ b/q2_types/per_sample_sequences/_type.py
@@ -28,26 +28,26 @@ plugin.register_semantic_types(Sequences, SequencesWithQuality,
 
 plugin.register_artifact_class(
     SampleData[Sequences],
-    artifact_format=QIIME1DemuxDirFmt,
+    directory_format=QIIME1DemuxDirFmt,
     description=("Collections of sequences associated with specified samples "
                  "(i.e., demultiplexed sequences).")
 )
 plugin.register_artifact_class(
     SampleData[SequencesWithQuality],
-    artifact_format=SingleLanePerSampleSingleEndFastqDirFmt,
+    directory_format=SingleLanePerSampleSingleEndFastqDirFmt,
     description=("Collections of sequences with quality scores associated "
                  "with specified samples (i.e., demultiplexed sequences).")
 )
 plugin.register_artifact_class(
     SampleData[JoinedSequencesWithQuality],
-    artifact_format=SingleLanePerSampleSingleEndFastqDirFmt,
+    directory_format=SingleLanePerSampleSingleEndFastqDirFmt,
     description=("Collections of joined paired-end sequences with quality "
                  "scores associated with specified samples (i.e., "
                  "demultiplexed sequences).")
 )
 plugin.register_artifact_class(
     SampleData[PairedEndSequencesWithQuality],
-    artifact_format=SingleLanePerSamplePairedEndFastqDirFmt,
+    directory_format=SingleLanePerSamplePairedEndFastqDirFmt,
     description=("Collections of unjoined paired-end sequences with quality "
                  "scores associated with specified samples (i.e., "
                  "demultiplexed sequences).")

--- a/q2_types/per_sample_sequences/_type.py
+++ b/q2_types/per_sample_sequences/_type.py
@@ -26,19 +26,29 @@ plugin.register_semantic_types(Sequences, SequencesWithQuality,
                                PairedEndSequencesWithQuality,
                                JoinedSequencesWithQuality)
 
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     SampleData[Sequences],
-    artifact_format=QIIME1DemuxDirFmt
+    artifact_format=QIIME1DemuxDirFmt,
+    description=("Collections of sequences associated with specified samples "
+                 "(i.e., demultiplexed sequences).")
 )
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     SampleData[SequencesWithQuality],
-    artifact_format=SingleLanePerSampleSingleEndFastqDirFmt
+    artifact_format=SingleLanePerSampleSingleEndFastqDirFmt,
+    description=("Collections of sequences with quality scores associated "
+                 "with specified samples (i.e., demultiplexed sequences).")
 )
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     SampleData[JoinedSequencesWithQuality],
-    artifact_format=SingleLanePerSampleSingleEndFastqDirFmt
+    artifact_format=SingleLanePerSampleSingleEndFastqDirFmt,
+    description=("Collections of joined paired-end sequences with quality "
+                 "scores associated with specified samples (i.e., "
+                 "demultiplexed sequences).")
 )
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     SampleData[PairedEndSequencesWithQuality],
-    artifact_format=SingleLanePerSamplePairedEndFastqDirFmt
+    artifact_format=SingleLanePerSamplePairedEndFastqDirFmt,
+    description=("Collections of unjoined paired-end sequences with quality "
+                 "scores associated with specified samples (i.e., "
+                 "demultiplexed sequences).")
 )

--- a/q2_types/sample_data/_type.py
+++ b/q2_types/sample_data/_type.py
@@ -21,5 +21,5 @@ plugin.register_semantic_types(SampleData, AlphaDiversity)
 
 plugin.register_semantic_type_to_format(
     SampleData[AlphaDiversity],
-    artifact_format=AlphaDiversityDirectoryFormat
+    directory_format=AlphaDiversityDirectoryFormat
 )

--- a/q2_types/tree/_type.py
+++ b/q2_types/tree/_type.py
@@ -27,11 +27,11 @@ Hierarchy = SemanticType('Hierarchy')
 plugin.register_semantic_types(Phylogeny, Rooted, Unrooted, Hierarchy)
 
 plugin.register_artifact_class(
-    Phylogeny[Rooted], NewickDirectoryFormat,
-    "A phylogenetic tree containing a defined root.")
+    Phylogeny[Unrooted], NewickDirectoryFormat,
+    "A phylogenetic tree not containing a defined root.")
 
-## Phylogeny[Unrooted] import usage example
-def phylogeny_unrooted_usage(use):
+## Phylogeny[Rooted] import usage example
+def phylogeny_rooted_usage(use):
     def factory():
         from q2_types.tree import NewickFormat
 
@@ -44,14 +44,14 @@ def phylogeny_unrooted_usage(use):
     to_import = use.init_format('my-tree', factory, ext='.tre')
 
     ints = use.import_from_format('tree',
-                                  semantic_type='Phylogeny[Unrooted]',
+                                  semantic_type='Phylogeny[Rooted]',
                                   variable=to_import,
                                   view_type='NewickFormat')
 
 plugin.register_artifact_class(
-    Phylogeny[Unrooted], NewickDirectoryFormat,
-    "A phylogenetic tree not containing a defined root.",
-    examples={'Import unrooted phylogenetic tree': phylogeny_unrooted_usage})
+    Phylogeny[Rooted], NewickDirectoryFormat,
+    "A phylogenetic tree containing a defined root.",
+    examples={'Import rooted phylogenetic tree': phylogeny_rooted_usage})
 
 plugin.register_semantic_type_to_format(Hierarchy,
                                         directory_format=NewickDirectoryFormat)

--- a/q2_types/tree/_type.py
+++ b/q2_types/tree/_type.py
@@ -6,11 +6,15 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+from io import StringIO
+
+from skbio import TreeNode
+
 from qiime2.plugin import SemanticType
+from qiime2.plugin.util import transform
 
 from ..plugin_setup import plugin
-from . import NewickDirectoryFormat
-
+from . import NewickFormat, NewickDirectoryFormat
 
 Phylogeny = SemanticType('Phylogeny', field_names=['type'])
 
@@ -26,9 +30,28 @@ plugin.register_artifact_class(
     Phylogeny[Rooted], NewickDirectoryFormat,
     "A phylogenetic tree containing a defined root.")
 
+## Phylogeny[Unrooted] import usage example
+def phylogeny_unrooted_usage(use):
+    def factory():
+        from q2_types.tree import NewickFormat
+
+        tree = TreeNode.read(StringIO(
+            '(SEQUENCE1:0.000000003,SEQUENCE2:0.000000003);'))
+        ff = transform(tree, to_type=NewickFormat)
+        ff.validate()
+        return ff
+
+    to_import = use.init_format('my-tree', factory, ext='.tre')
+
+    ints = use.import_from_format('tree',
+                                  semantic_type='Phylogeny[Unrooted]',
+                                  variable=to_import,
+                                  view_type='NewickFormat')
+
 plugin.register_artifact_class(
     Phylogeny[Unrooted], NewickDirectoryFormat,
-    "A phylogenetic tree not containing a defined root.")
+    "A phylogenetic tree not containing a defined root.",
+    examples={'Import unrooted phylogenetic tree': phylogeny_unrooted_usage})
 
 plugin.register_semantic_type_to_format(Hierarchy,
                                         directory_format=NewickDirectoryFormat)

--- a/q2_types/tree/_type.py
+++ b/q2_types/tree/_type.py
@@ -14,7 +14,7 @@ from qiime2.plugin import SemanticType
 from qiime2.plugin.util import transform
 
 from ..plugin_setup import plugin
-from . import NewickFormat, NewickDirectoryFormat
+from . import NewickDirectoryFormat
 
 Phylogeny = SemanticType('Phylogeny', field_names=['type'])
 
@@ -30,7 +30,8 @@ plugin.register_artifact_class(
     Phylogeny[Unrooted], NewickDirectoryFormat,
     "A phylogenetic tree not containing a defined root.")
 
-## Phylogeny[Rooted] import usage example
+
+# Phylogeny[Rooted] import usage example
 def phylogeny_rooted_usage(use):
     def factory():
         from q2_types.tree import NewickFormat
@@ -43,10 +44,11 @@ def phylogeny_rooted_usage(use):
 
     to_import = use.init_format('my-tree', factory, ext='.tre')
 
-    ints = use.import_from_format('tree',
-                                  semantic_type='Phylogeny[Rooted]',
-                                  variable=to_import,
-                                  view_type='NewickFormat')
+    use.import_from_format('tree',
+                           semantic_type='Phylogeny[Rooted]',
+                           variable=to_import,
+                           view_type='NewickFormat')
+
 
 plugin.register_artifact_class(
     Phylogeny[Rooted], NewickDirectoryFormat,

--- a/q2_types/tree/_type.py
+++ b/q2_types/tree/_type.py
@@ -31,4 +31,4 @@ plugin.register_artifact_class(
     "A phylogenetic tree not containing a defined root.")
 
 plugin.register_semantic_type_to_format(Hierarchy,
-                                        artifact_format=NewickDirectoryFormat)
+                                        directory_format=NewickDirectoryFormat)

--- a/q2_types/tree/_type.py
+++ b/q2_types/tree/_type.py
@@ -22,8 +22,13 @@ Hierarchy = SemanticType('Hierarchy')
 
 plugin.register_semantic_types(Phylogeny, Rooted, Unrooted, Hierarchy)
 
-plugin.register_semantic_type_to_format(Phylogeny[Rooted | Unrooted],
-                                        artifact_format=NewickDirectoryFormat)
+plugin.register_artifact_class(
+    Phylogeny[Rooted], NewickDirectoryFormat,
+    "A phylogenetic tree containing a defined root.")
+
+plugin.register_artifact_class(
+    Phylogeny[Unrooted], NewickDirectoryFormat,
+    "A phylogenetic tree not containing a defined root.")
 
 plugin.register_semantic_type_to_format(Hierarchy,
                                         artifact_format=NewickDirectoryFormat)

--- a/q2_types/tree/tests/test_type.py
+++ b/q2_types/tree/tests/test_type.py
@@ -30,7 +30,9 @@ class TestTypes(TestPluginBase):
 
     def test_phylogeny_rooted_unrooted_to_newick_dir_fmt_registration(self):
         self.assertSemanticTypeRegisteredToFormat(
-            Phylogeny[Rooted | Unrooted], NewickDirectoryFormat)
+            Phylogeny[Rooted], NewickDirectoryFormat)
+        self.assertSemanticTypeRegisteredToFormat(
+            Phylogeny[Unrooted], NewickDirectoryFormat)
 
     def test_hierarchy_to_newick_dir_fmt_registration(self):
         self.assertSemanticTypeRegisteredToFormat(


### PR DESCRIPTION
This pull request depends on https://github.com/qiime2/qiime2/pull/655. 

This makes changes to tests to:
* handle new behavior associated with that PR (semantic types rather than type expressions are registered to formats for artifact classes), 
* to update to new parameter names (`directory_format` instead of `artifact_format`, though `artifact_format` is still supported when calling `Plugin.register_semantic_type_to_format`) 
* add a few artifact class descriptions and usage examples for initial testing purposes. 

In a development environment with the above `qiime2` branch installed, this can be tested as follows:

## Access descriptions of artifact classes

```python
from qiime2.sdk import PluginManager
pm = PluginManager()

pm.get_semantic_types()
pm.get_semantic_types()['Phylogeny[Rooted]']
pm.get_semantic_types()['Phylogeny[Rooted]'].description
'A phylogenetic tree containing a defined root.'

for e in pm.get_semantic_types().values():
    desc = e.description or "No description provided."
    print('%s : %s' % (e.type_expression, desc))

FeatureTable[PresenceAbsence] : No description provided.
FeatureTable[Design] : No description provided.
FeatureTable[Frequency] : No description provided.
FeatureTable[PercentileNormalized] : No description provided.
FeatureTable[Composition] : No description provided.
FeatureTable[Balance] : No description provided.
FeatureTable[RelativeFrequency] : No description provided.
DistanceMatrix : No description provided.
Phylogeny[Rooted] : A phylogenetic tree containing a defined root.
Phylogeny[Unrooted] : A phylogenetic tree not containing a defined root.
Hierarchy : No description provided.
PCoAResults : No description provided.
ProcrustesStatistics : No description provided.
SampleData[AlphaDiversity] : No description provided.
SampleData[Sequences] : Collections of sequences associated with specified samples (i.e., demultiplexed sequences).
SampleData[SequencesWithQuality] : Collections of sequences with quality scores associated with specified samples (i.e., demultiplexed sequences).
SampleData[JoinedSequencesWithQuality] : Collections of joined paired-end sequences with quality scores associated with specified samples (i.e., demultiplexed sequences).
SampleData[PairedEndSequencesWithQuality] : Collections of unjoined paired-end sequences with quality scores associated with specified samples (i.e., demultiplexed sequences).
MultiplexedSingleEndBarcodeInSequence : No description provided.
MultiplexedPairedEndBarcodeInSequence : No description provided.
Bowtie2Index : No description provided.
FeatureData[Taxonomy] : No description provided.
FeatureData[Sequence] : No description provided.
FeatureData[RNASequence] : No description provided.
FeatureData[PairedEndSequence] : No description provided.
FeatureData[PairedEndRNASequence] : No description provided.
FeatureData[AlignedSequence] : No description provided.
FeatureData[AlignedRNASequence] : No description provided.
FeatureData[Differential] : No description provided.
FeatureData[ProteinSequence] : No description provided.
FeatureData[AlignedProteinSequence] : No description provided.
FeatureData[BLAST6] : No description provided.
RawSequences : No description provided.
EMPSingleEndSequences : No description provided.
EMPPairedEndSequences : No description provided.
ErrorCorrectionDetails : No description provided.
SampleData[ArtificialGrouping] : No description provided.
TaxonomicClassifier : No description provided.
SampleData[DADA2Stats] : No description provided.
SampleEstimator[Classifier] : No description provided.
SampleEstimator[Regressor] : No description provided.
SampleData[BooleanSeries] : No description provided.
SampleData[RegressorPredictions] : No description provided.
SampleData[ClassifierPredictions] : No description provided.
FeatureData[Importance] : No description provided.
SampleData[Probabilities] : No description provided.
SampleData[TrueTargets] : No description provided.
QualityFilterStats : No description provided.
UchimeStats : No description provided.
SampleData[FirstDifferences] : No description provided.
DeblurStats : No description provided.
Placements : No description provided.
SeppReferenceDatabase : No description provided.
```

## Generate data and render an import usage example

```python
from qiime2.sdk import PluginManager
import qiime2.plugins

pm = PluginManager()
use = qiime2.plugins.ArtifactAPIUsage()

ex1 = pm.get_semantic_types()['Phylogeny[Unrooted]'].examples['Import unrooted phylogenetic tree']

ex1(use)

print(use.render())

d = use.get_example_data()

d['my-tree.tre'].save('my-tree.tre')
```