### PR TITLE
add artifact class annotations

### DIFF
--- a/q2_types/bowtie2/_types.py
+++ b/q2_types/bowtie2/_types.py
@@ -17,4 +17,4 @@ from ..plugin_setup import plugin
 Bowtie2Index = SemanticType('Bowtie2Index')
 
 plugin.register_semantic_types(Bowtie2Index)
-plugin.register_semantic_type_to_format(Bowtie2Index, Bowtie2IndexDirFmt)
+plugin.register_artifact_class(Bowtie2Index, Bowtie2IndexDirFmt)

--- a/q2_types/distance_matrix/_type.py
+++ b/q2_types/distance_matrix/_type.py
@@ -17,5 +17,6 @@ DistanceMatrix = SemanticType('DistanceMatrix')
 plugin.register_semantic_types(DistanceMatrix)
 plugin.register_artifact_class(
     DistanceMatrix,
-    directory_format=DistanceMatrixDirectoryFormat
+    directory_format=DistanceMatrixDirectoryFormat,
+    description="A symmetric matrix representing distances between entities."
 )

--- a/q2_types/distance_matrix/_type.py
+++ b/q2_types/distance_matrix/_type.py
@@ -15,7 +15,7 @@ from . import DistanceMatrixDirectoryFormat
 DistanceMatrix = SemanticType('DistanceMatrix')
 
 plugin.register_semantic_types(DistanceMatrix)
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     DistanceMatrix,
     directory_format=DistanceMatrixDirectoryFormat
 )

--- a/q2_types/feature_data/_type.py
+++ b/q2_types/feature_data/_type.py
@@ -59,13 +59,25 @@ plugin.register_semantic_types(FeatureData, Taxonomy, Sequence,
 
 plugin.register_artifact_class(
     FeatureData[Taxonomy],
-    directory_format=TSVTaxonomyDirectoryFormat)
+    directory_format=TSVTaxonomyDirectoryFormat,
+    description=("Hierarchical metadata or annotations associated with a set "
+                 "of features. This can contain one or more hierarchical "
+                 "levels, and annotations can be anything (e.g., taxonomy of "
+                 "organisms, functional categorization of gene families, ...) "
+                 "as long as it is strictly hierarchical."))
 plugin.register_artifact_class(
     FeatureData[Sequence],
-    directory_format=DNASequencesDirectoryFormat)
+    directory_format=DNASequencesDirectoryFormat,
+    description=("Unaligned DNA sequences associated with a set of feature "
+                 "identifiers (e.g., ASV sequences or OTU representative "
+                 "sequence). Exactly one sequence is associated with each "
+                 "feature identfiier."))
 plugin.register_artifact_class(
     FeatureData[RNASequence],
-    directory_format=RNASequencesDirectoryFormat)
+    directory_format=RNASequencesDirectoryFormat,
+    description=("Unaligned RNA sequences associated with a set of feature "
+                 "identifiers. Exactly one sequence is associated with each "
+                 "feature identfiier."))
 plugin.register_artifact_class(
     FeatureData[PairedEndSequence],
     directory_format=PairedDNASequencesDirectoryFormat)
@@ -74,18 +86,34 @@ plugin.register_artifact_class(
     directory_format=PairedRNASequencesDirectoryFormat)
 plugin.register_artifact_class(
     FeatureData[AlignedSequence],
-    directory_format=AlignedDNASequencesDirectoryFormat)
+    directory_format=AlignedDNASequencesDirectoryFormat,
+    description=("Aligned DNA sequences associated with a set of feature "
+                 "identifiers (e.g., aligned ASV sequences or OTU "
+                 "representative sequence). Exactly one sequence is "
+                 "associated with each feature identfiier."))
 plugin.register_artifact_class(
     FeatureData[AlignedRNASequence],
-    directory_format=AlignedRNASequencesDirectoryFormat)
+    directory_format=AlignedRNASequencesDirectoryFormat,
+    description=("Aligned RNA sequences associated with a set of feature "
+                 "identifiers. Exactly one sequence is associated with each "
+                 "feature identfiier."))
 plugin.register_artifact_class(
     FeatureData[Differential], DifferentialDirectoryFormat)
 plugin.register_artifact_class(
     FeatureData[ProteinSequence],
-    directory_format=ProteinSequencesDirectoryFormat)
+    directory_format=ProteinSequencesDirectoryFormat,
+    description=("Unaligned protein sequences associated with a set of "
+                 "feature identifiers. Exactly one sequence is associated "
+                 "with each feature identfiier."))
 plugin.register_artifact_class(
     FeatureData[AlignedProteinSequence],
-    directory_format=AlignedProteinSequencesDirectoryFormat)
+    directory_format=AlignedProteinSequencesDirectoryFormat,
+    description=("Aligned protein sequences associated with a set of "
+                 "feature identifiers. Exactly one sequence is associated "
+                 "with each feature identfiier."))
+# FeatureData[BLAST6] seems to fix file type with semantic type.
 plugin.register_artifact_class(
     FeatureData[BLAST6],
-    directory_format=BLAST6DirectoryFormat)
+    directory_format=BLAST6DirectoryFormat,
+    description=("BLAST results associated with a set of feature "
+                 "identifiers."))

--- a/q2_types/feature_data/_type.py
+++ b/q2_types/feature_data/_type.py
@@ -57,35 +57,35 @@ plugin.register_semantic_types(FeatureData, Taxonomy, Sequence,
                                BLAST6)
 
 
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     FeatureData[Taxonomy],
     directory_format=TSVTaxonomyDirectoryFormat)
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     FeatureData[Sequence],
     directory_format=DNASequencesDirectoryFormat)
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     FeatureData[RNASequence],
     directory_format=RNASequencesDirectoryFormat)
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     FeatureData[PairedEndSequence],
     directory_format=PairedDNASequencesDirectoryFormat)
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     FeatureData[PairedEndRNASequence],
     directory_format=PairedRNASequencesDirectoryFormat)
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     FeatureData[AlignedSequence],
     directory_format=AlignedDNASequencesDirectoryFormat)
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     FeatureData[AlignedRNASequence],
     directory_format=AlignedRNASequencesDirectoryFormat)
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     FeatureData[Differential], DifferentialDirectoryFormat)
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     FeatureData[ProteinSequence],
     directory_format=ProteinSequencesDirectoryFormat)
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     FeatureData[AlignedProteinSequence],
     directory_format=AlignedProteinSequencesDirectoryFormat)
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     FeatureData[BLAST6],
     directory_format=BLAST6DirectoryFormat)

--- a/q2_types/feature_table/_type.py
+++ b/q2_types/feature_table/_type.py
@@ -39,7 +39,7 @@ plugin.register_semantic_types(FeatureTable, Frequency, RelativeFrequency,
                                PresenceAbsence, Balance, Composition,
                                PercentileNormalized, Design)
 
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     FeatureTable[Frequency | RelativeFrequency |
                  PresenceAbsence | Balance | Composition |
                  PercentileNormalized | Design],

--- a/q2_types/feature_table/_type.py
+++ b/q2_types/feature_table/_type.py
@@ -40,8 +40,49 @@ plugin.register_semantic_types(FeatureTable, Frequency, RelativeFrequency,
                                PercentileNormalized, Design)
 
 plugin.register_artifact_class(
-    FeatureTable[Frequency | RelativeFrequency |
-                 PresenceAbsence | Balance | Composition |
-                 PercentileNormalized | Design],
+    FeatureTable[Frequency],
+    directory_format=BIOMV210DirFmt,
+    description=("A feature table (e.g., samples by ASVs) where each value "
+                 "in the matrix is a whole number greater than or equal to "
+                 "0 representing the frequency or count of a feature in "
+                 "the corresponding sample. These data should be raw "
+                 "(not normalized) counts.")
+)
+plugin.register_artifact_class(
+    FeatureTable[RelativeFrequency],
+    directory_format=BIOMV210DirFmt,
+    description=("A feature table (e.g., samples by ASVs) where each value "
+                 "in the matrix is a real number greater than or equal to "
+                 "0.0 and less than or equal to 1.0 representing the "
+                 "proportion of the sample that is composed of that feature. "
+                 "The feature values for each sample should sum to 1.0.")
+)
+plugin.register_artifact_class(
+    FeatureTable[PresenceAbsence],
+    directory_format=BIOMV210DirFmt,
+    description=("A feature table (e.g., samples by ASVs) where each value "
+                 "indicates is a boolean indication of whether the feature "
+                 "is observed in the sample or not.")
+)
+plugin.register_artifact_class(
+    FeatureTable[Balance],
+    directory_format=BIOMV210DirFmt
+)
+plugin.register_artifact_class(
+    FeatureTable[Composition],
+    directory_format=BIOMV210DirFmt,
+    description=("A feature table (e.g., samples by ASVs) where each value "
+                 "in the matrix is a whole number greater than "
+                 "0 representing the frequency or count of a feature in "
+                 "the corresponding sample. These data are typically not "
+                 "raw counts, having been transformed in some way to exclude "
+                 "zero counts.")
+)
+plugin.register_artifact_class(
+    FeatureTable[PercentileNormalized],
+    directory_format=BIOMV210DirFmt
+)
+plugin.register_artifact_class(
+    FeatureTable[Design],
     directory_format=BIOMV210DirFmt
 )

--- a/q2_types/multiplexed_sequences/_type.py
+++ b/q2_types/multiplexed_sequences/_type.py
@@ -23,9 +23,16 @@ plugin.register_semantic_types(MultiplexedSingleEndBarcodeInSequence,
 
 plugin.register_artifact_class(
     MultiplexedSingleEndBarcodeInSequence,
-    directory_format=MultiplexedSingleEndBarcodeInSequenceDirFmt
+    directory_format=MultiplexedSingleEndBarcodeInSequenceDirFmt,
+    description=("Multiplexed sequences (i.e., representing multiple "
+                 "difference samples), which are single-end reads, and which "
+                 "contain the barcode (i.e., index) indicating the source "
+                 "sample as part of the sequence read.")
 )
 plugin.register_artifact_class(
     MultiplexedPairedEndBarcodeInSequence,
     directory_format=MultiplexedPairedEndBarcodeInSequenceDirFmt,
-)
+    description=("Multiplexed sequences (i.e., representing multiple "
+                 "difference samples), which are paired-end reads, and which "
+                 "contain the barcode (i.e., index) indicating the source "
+                 "sample as part of the sequence read.")

--- a/q2_types/multiplexed_sequences/_type.py
+++ b/q2_types/multiplexed_sequences/_type.py
@@ -21,11 +21,11 @@ MultiplexedPairedEndBarcodeInSequence = \
 plugin.register_semantic_types(MultiplexedSingleEndBarcodeInSequence,
                                MultiplexedPairedEndBarcodeInSequence)
 
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     MultiplexedSingleEndBarcodeInSequence,
     directory_format=MultiplexedSingleEndBarcodeInSequenceDirFmt
 )
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     MultiplexedPairedEndBarcodeInSequence,
     directory_format=MultiplexedPairedEndBarcodeInSequenceDirFmt,
 )

--- a/q2_types/multiplexed_sequences/_type.py
+++ b/q2_types/multiplexed_sequences/_type.py
@@ -36,3 +36,4 @@ plugin.register_artifact_class(
                  "difference samples), which are paired-end reads, and which "
                  "contain the barcode (i.e., index) indicating the source "
                  "sample as part of the sequence read.")
+)

--- a/q2_types/ordination/_type.py
+++ b/q2_types/ordination/_type.py
@@ -19,11 +19,12 @@ ProcrustesStatistics = SemanticType('ProcrustesStatistics')
 plugin.register_semantic_types(PCoAResults, ProcrustesStatistics)
 plugin.register_artifact_class(
     PCoAResults,
-    directory_format=OrdinationDirectoryFormat
+    directory_format=OrdinationDirectoryFormat,
+    description="The results of running principal coordinate analysis (PCoA)."
 )
 
 plugin.register_artifact_class(
     ProcrustesStatistics,
-
-    directory_format=ProcrustesStatisticsDirFmt
+    directory_format=ProcrustesStatisticsDirFmt,
+    description="The results of running Procrustes analysis."
 )

--- a/q2_types/ordination/_type.py
+++ b/q2_types/ordination/_type.py
@@ -17,12 +17,12 @@ PCoAResults = SemanticType('PCoAResults')
 ProcrustesStatistics = SemanticType('ProcrustesStatistics')
 
 plugin.register_semantic_types(PCoAResults, ProcrustesStatistics)
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     PCoAResults,
     directory_format=OrdinationDirectoryFormat
 )
 
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     ProcrustesStatistics,
 
     directory_format=ProcrustesStatisticsDirFmt

--- a/q2_types/sample_data/_type.py
+++ b/q2_types/sample_data/_type.py
@@ -21,5 +21,7 @@ plugin.register_semantic_types(SampleData, AlphaDiversity)
 
 plugin.register_artifact_class(
     SampleData[AlphaDiversity],
-    directory_format=AlphaDiversityDirectoryFormat
+    directory_format=AlphaDiversityDirectoryFormat,
+    description=("Alpha diversity values, each associated with a single "
+                 "sample identifier.")
 )

--- a/q2_types/sample_data/_type.py
+++ b/q2_types/sample_data/_type.py
@@ -19,7 +19,7 @@ AlphaDiversity = SemanticType('AlphaDiversity',
 
 plugin.register_semantic_types(SampleData, AlphaDiversity)
 
-plugin.register_semantic_type_to_format(
+plugin.register_artifact_class(
     SampleData[AlphaDiversity],
     directory_format=AlphaDiversityDirectoryFormat
 )

--- a/q2_types/tree/_type.py
+++ b/q2_types/tree/_type.py
@@ -55,5 +55,5 @@ plugin.register_artifact_class(
     "A phylogenetic tree containing a defined root.",
     examples={'Import rooted phylogenetic tree': phylogeny_rooted_usage})
 
-plugin.register_semantic_type_to_format(Hierarchy,
-                                        directory_format=NewickDirectoryFormat)
+plugin.register_artifact_class(Hierarchy,
+                               directory_format=NewickDirectoryFormat)


### PR DESCRIPTION
Add annotations of artifact classes. This PR is primarily moving [artifact class descriptions from our static docs](https://docs.qiime2.org/2022.8/semantic-types/) to the descriptions on the artifact classes themselves. 
