### PR TITLE
BUG: fix circular imports in bowtie/contig

### DIFF
--- a/q2_types/bowtie2/__init__.py
+++ b/q2_types/bowtie2/__init__.py
@@ -9,5 +9,9 @@
 from ._formats import (Bowtie2IndexFileFormat, Bowtie2IndexDirFmt)
 from ._types import Bowtie2Index
 
+from ..plugin_setup import plugin, citations
+
+plugin.register_views(Bowtie2IndexDirFmt,
+                      citations=[citations['langmead2012fast']])
 
 __all__ = ['Bowtie2IndexFileFormat', 'Bowtie2IndexDirFmt', 'Bowtie2Index']

--- a/q2_types/bowtie2/_formats.py
+++ b/q2_types/bowtie2/_formats.py
@@ -9,7 +9,6 @@
 import itertools
 
 from qiime2.plugin import model
-from ..plugin_setup import plugin, citations
 
 
 class Bowtie2IndexFileFormat(model.BinaryFileFormat):
@@ -44,7 +43,3 @@ def _get_prefix(strings):
     char_tuples = zip(*strings)
     prefix_tuples = itertools.takewhile(all_same, char_tuples)
     return ''.join(x[0] for x in prefix_tuples)
-
-
-plugin.register_views(Bowtie2IndexDirFmt,
-                      citations=[citations['langmead2012fast']])

--- a/q2_types/plugin_setup.py
+++ b/q2_types/plugin_setup.py
@@ -6,8 +6,6 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import importlib
-
 import pandas as pd
 import qiime2.plugin
 import qiime2.sdk
@@ -28,17 +26,4 @@ plugin = qiime2.plugin.Plugin(
 plugin.register_views(pd.Series, pd.DataFrame,
                       citations=[citations['mckinney-proc-scipy-2010']])
 
-importlib.import_module('q2_types.feature_table')
-importlib.import_module('q2_types.distance_matrix')
-importlib.import_module('q2_types.tree')
-importlib.import_module('q2_types.ordination')
-importlib.import_module('q2_types.sample_data')
-importlib.import_module('q2_types.feature_data')
-importlib.import_module('q2_types.per_sample_sequences')
-importlib.import_module('q2_types.multiplexed_sequences')
-importlib.import_module('q2_types.bowtie2')
-importlib.import_module('q2_types.kraken2')
-importlib.import_module('q2_types.feature_data_mag')
-importlib.import_module('q2_types.genome_data')
-importlib.import_module('q2_types.kaiju')
-importlib.import_module('q2_types.reference_db')
+# __init__.py loads first and imports all of the subpackages.


### PR DESCRIPTION
Lets the format load before registration.

Also use the __init__ exclusively for loading subpackages.