### PR TITLE
ENH: add `FeatureData[SingleBowtie2Index]` and `FeatureData[AlignmentMap]`

### DIFF
--- a/q2_types/feature_data_mag/_type.py
+++ b/q2_types/feature_data_mag/_type.py
@@ -13,7 +13,8 @@ from q2_types.feature_data_mag._format import (
         )
 from qiime2.core.type import SemanticType
 
-from ..per_sample_sequences import ContigSequencesDirFmt
+from ..bowtie2 import Bowtie2IndexDirFmt
+from ..per_sample_sequences import ContigSequencesDirFmt, SingleBowtie2Index
 from ..plugin_setup import plugin
 
 
@@ -55,3 +56,8 @@ plugin.register_semantic_types(KEGG)
 plugin.register_artifact_class(
         FeatureData[KEGG],
         directory_format=OrthologAnnotationDirFmt)
+
+plugin.register_semantic_type_to_format(
+    FeatureData[SingleBowtie2Index],
+    artifact_format=Bowtie2IndexDirFmt
+)

--- a/q2_types/feature_data_mag/tests/test_type.py
+++ b/q2_types/feature_data_mag/tests/test_type.py
@@ -8,6 +8,7 @@
 
 import unittest
 
+from q2_types.bowtie2 import Bowtie2IndexDirFmt
 from q2_types.feature_data import FeatureData
 from qiime2.plugin.testing import TestPluginBase
 
@@ -15,7 +16,7 @@ from q2_types.feature_data_mag import (
         MAG, MAGSequencesDirFmt, OrthologAnnotationDirFmt,
         NOG, OG, KEGG, Contig
 )
-from q2_types.per_sample_sequences import ContigSequencesDirFmt
+from q2_types.per_sample_sequences import ContigSequencesDirFmt, SingleBowtie2Index
 
 
 class TestTypes(TestPluginBase):
@@ -62,6 +63,12 @@ class TestTypes(TestPluginBase):
         self.assertSemanticTypeRegisteredToFormat(
                 FeatureData[KEGG],
                 OrthologAnnotationDirFmt)
+
+    def test_bowtie_index_semantic_type_to_format_registration(self):
+        self.assertSemanticTypeRegisteredToFormat(
+            FeatureData[SingleBowtie2Index],
+            Bowtie2IndexDirFmt
+        )
 
 
 if __name__ == '__main__':

--- a/q2_types/feature_data_mag/tests/test_type.py
+++ b/q2_types/feature_data_mag/tests/test_type.py
@@ -16,7 +16,9 @@ from q2_types.feature_data_mag import (
         MAG, MAGSequencesDirFmt, OrthologAnnotationDirFmt,
         NOG, OG, KEGG, Contig
 )
-from q2_types.per_sample_sequences import ContigSequencesDirFmt, SingleBowtie2Index
+from q2_types.per_sample_sequences import (
+    ContigSequencesDirFmt, SingleBowtie2Index
+)
 
 
 class TestTypes(TestPluginBase):

--- a/q2_types/per_sample_sequences/_type.py
+++ b/q2_types/per_sample_sequences/_type.py
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from q2_types.bowtie2 import Bowtie2IndexDirFmt
-from q2_types.feature_data import BLAST6
+from q2_types.feature_data import BLAST6, FeatureData
 from qiime2.plugin import SemanticType
 
 from ..genome_data import SeedOrthologDirFmt
@@ -31,11 +31,15 @@ MAGs = SemanticType(
 Contigs = SemanticType(
     'Contigs', variant_of=SampleData.field['type'])
 SingleBowtie2Index = SemanticType(
-    'SingleBowtie2Index', variant_of=SampleData.field['type'])
+    'SingleBowtie2Index',
+    variant_of=[SampleData.field['type'], FeatureData.field['type']]
+)
 MultiBowtie2Index = SemanticType(
     'MultiBowtie2Index', variant_of=SampleData.field['type'])
 AlignmentMap = SemanticType(
-    'AlignmentMap', variant_of=SampleData.field['type'])
+    'AlignmentMap',
+    variant_of=[SampleData.field['type'], FeatureData.field['type']]
+)
 MultiAlignmentMap = SemanticType(
     'MultiAlignmentMap', variant_of=SampleData.field['type'])
 
@@ -88,6 +92,10 @@ plugin.register_semantic_type_to_format(
 )
 plugin.register_semantic_type_to_format(
     SampleData[AlignmentMap],
+    artifact_format=BAMDirFmt
+)
+plugin.register_semantic_type_to_format(
+    FeatureData[AlignmentMap],
     artifact_format=BAMDirFmt
 )
 plugin.register_semantic_type_to_format(

--- a/q2_types/per_sample_sequences/tests/test_type.py
+++ b/q2_types/per_sample_sequences/tests/test_type.py
@@ -9,7 +9,7 @@
 import unittest
 
 from q2_types.bowtie2 import Bowtie2IndexDirFmt
-from q2_types.feature_data import BLAST6
+from q2_types.feature_data import BLAST6, FeatureData
 from q2_types.sample_data import SampleData
 from q2_types.per_sample_sequences import (
     Sequences, SequencesWithQuality, PairedEndSequencesWithQuality,
@@ -87,9 +87,15 @@ class TestTypes(TestPluginBase):
     def test_singlebowtie_semantic_type_registration(self):
         self.assertRegisteredSemanticType(SingleBowtie2Index)
 
-    def test_singlebowtie_semantic_type_to_format_registration(self):
+    def test_singlebowtie_sd_semantic_type_to_format_registration(self):
         self.assertSemanticTypeRegisteredToFormat(
             SampleData[SingleBowtie2Index],
+            Bowtie2IndexDirFmt
+        )
+
+    def test_singlebowtie_fd_semantic_type_to_format_registration(self):
+        self.assertSemanticTypeRegisteredToFormat(
+            FeatureData[SingleBowtie2Index],
             Bowtie2IndexDirFmt
         )
 
@@ -105,9 +111,15 @@ class TestTypes(TestPluginBase):
     def test_aln_map_semantic_type_registration(self):
         self.assertRegisteredSemanticType(AlignmentMap)
 
-    def test_aln_map_semantic_type_to_format_registration(self):
+    def test_aln_map_sd_semantic_type_to_format_registration(self):
         self.assertSemanticTypeRegisteredToFormat(
             SampleData[AlignmentMap],
+            BAMDirFmt
+        )
+
+    def test_aln_map_fd_semantic_type_to_format_registration(self):
+        self.assertSemanticTypeRegisteredToFormat(
+            FeatureData[AlignmentMap],
             BAMDirFmt
         )
 


### PR DESCRIPTION
This PR adds two new semantic types:
- `FeatureData[SingleBowtie2Index]`
- `FeatureData[AlignmentMap]`.

They are required for the expansion of the indexing and mapping actions in q2-assembly (to further enable MAG normalization): https://github.com/bokulich-lab/q2-assembly/pull/81
