### PR TITLE
Use ConfigParser instead of SafeConfigParser

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -340,9 +340,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
The configparser's SafeConfigParser has been renamed to ConfigParser in Python 3.2 [1]. It was finally removed in Python 3.12 [2].

[1] https://docs.python.org/dev/whatsnew/3.2.html#configparser
[2] https://docs.python.org/3/whatsnew/3.12.html#configparser

Brief summary of the Pull Request, including any issues it may fix using the GitHub closing syntax:

https://help.github.com/articles/closing-issues-using-keywords/

Also, include any co-authors or contributors using the GitHub coauthor tag:

https://help.github.com/articles/creating-a-commit-with-multiple-authors/

---

Include any questions for reviewers, screenshots, sample outputs, etc.
