### PR TITLE
FIX: correctly generate the MANIFEST when collating SampleData[MAGs]

### DIFF
--- a/q2_types/per_sample_sequences/_methods.py
+++ b/q2_types/per_sample_sequences/_methods.py
@@ -77,13 +77,24 @@ def collate_sample_data_mags(
 
                 # For every mag in the sample
                 for mag in sample.iterdir():
-                    duplicate(mag, collated_mags.path / sample.name / mag.name)
+                    duplicate(
+                        mag, collated_mags.path / sample.name / mag.name
+                    )
 
-            # If its a file, it should be the manifest
-            # Since its present many times it will be overwritten, but that ok
+            # If it's a file, it should be the manifest
             else:
                 manifest = file_or_dir
-                # Overwrite is necessary
-                shutil.copy(manifest, collated_mags.path / manifest.name)
+                # If it's the first manifest, copy it over
+                if not (collated_mags.path / manifest.name).exists():
+                    shutil.copy(manifest, collated_mags.path / manifest.name)
+                else:
+                    # Append entries (except header) to the existing manifest
+                    with (
+                        open(manifest, 'r') as src,
+                        open(collated_mags.path / manifest.name, 'a') as dest
+                    ):
+                        next(src)  # Skip header
+                        for line in src:
+                            dest.write(line)
 
     return collated_mags

--- a/q2_types/per_sample_sequences/tests/data/collated_mags/MANIFEST
+++ b/q2_types/per_sample_sequences/tests/data/collated_mags/MANIFEST
@@ -1,7 +1,4 @@
 sample-id,mag-id,filename
-sample1,ca7012fc-ba65-40c3-84f5-05aa478a7585,sample1/ca7012fc-ba65-40c3-84f5-05aa478a7585.fasta
-sample1,fb0bc871-04f6-486b-a10e-8e0cb66f8de3,sample1/fb0bc871-04f6-486b-a10e-8e0cb66f8de3.fasta
 sample1,24dee6fe-9b84-45bb-8145-de7b092533a1,sample1/24dee6fe-9b84-45bb-8145-de7b092533a1.fasta
-sample2,db03f8b6-28e1-48c5-a47c-9c65f38f7357,sample2/db03f8b6-28e1-48c5-a47c-9c65f38f7357.fasta
+sample1,fb0bc871-04f6-486b-a10e-8e0cb66f8de3,sample1/fb0bc871-04f6-486b-a10e-8e0cb66f8de3.fasta
 sample2,d65a71fa-4279-4588-b937-0747ed5d604d,sample2/d65a71fa-4279-4588-b937-0747ed5d604d.fasta
-sample2,fa4d7420-d0a4-455a-b4d7-4fa66e54c9bf,sample2/fa4d7420-d0a4-455a-b4d7-4fa66e54c9bf.fasta

--- a/q2_types/per_sample_sequences/tests/data/partitioned_mags/mag1/MANIFEST
+++ b/q2_types/per_sample_sequences/tests/data/partitioned_mags/mag1/MANIFEST
@@ -1,7 +1,3 @@
 sample-id,mag-id,filename
-sample1,ca7012fc-ba65-40c3-84f5-05aa478a7585,sample1/ca7012fc-ba65-40c3-84f5-05aa478a7585.fasta
-sample1,fb0bc871-04f6-486b-a10e-8e0cb66f8de3,sample1/fb0bc871-04f6-486b-a10e-8e0cb66f8de3.fasta
 sample1,24dee6fe-9b84-45bb-8145-de7b092533a1,sample1/24dee6fe-9b84-45bb-8145-de7b092533a1.fasta
-sample2,db03f8b6-28e1-48c5-a47c-9c65f38f7357,sample2/db03f8b6-28e1-48c5-a47c-9c65f38f7357.fasta
-sample2,d65a71fa-4279-4588-b937-0747ed5d604d,sample2/d65a71fa-4279-4588-b937-0747ed5d604d.fasta
-sample2,fa4d7420-d0a4-455a-b4d7-4fa66e54c9bf,sample2/fa4d7420-d0a4-455a-b4d7-4fa66e54c9bf.fasta
+sample1,fb0bc871-04f6-486b-a10e-8e0cb66f8de3,sample1/fb0bc871-04f6-486b-a10e-8e0cb66f8de3.fasta

--- a/q2_types/per_sample_sequences/tests/data/partitioned_mags/mag2/MANIFEST
+++ b/q2_types/per_sample_sequences/tests/data/partitioned_mags/mag2/MANIFEST
@@ -1,7 +1,2 @@
 sample-id,mag-id,filename
-sample1,ca7012fc-ba65-40c3-84f5-05aa478a7585,sample1/ca7012fc-ba65-40c3-84f5-05aa478a7585.fasta
-sample1,fb0bc871-04f6-486b-a10e-8e0cb66f8de3,sample1/fb0bc871-04f6-486b-a10e-8e0cb66f8de3.fasta
-sample1,24dee6fe-9b84-45bb-8145-de7b092533a1,sample1/24dee6fe-9b84-45bb-8145-de7b092533a1.fasta
-sample2,db03f8b6-28e1-48c5-a47c-9c65f38f7357,sample2/db03f8b6-28e1-48c5-a47c-9c65f38f7357.fasta
 sample2,d65a71fa-4279-4588-b937-0747ed5d604d,sample2/d65a71fa-4279-4588-b937-0747ed5d604d.fasta
-sample2,fa4d7420-d0a4-455a-b4d7-4fa66e54c9bf,sample2/fa4d7420-d0a4-455a-b4d7-4fa66e54c9bf.fasta

--- a/q2_types/per_sample_sequences/tests/test_methods.py
+++ b/q2_types/per_sample_sequences/tests/test_methods.py
@@ -101,3 +101,11 @@ class TestSampleDataMAGsPartitionCollating(TestPluginBase):
             ["d65a71fa-4279-4588-b937-0747ed5d604d.fasta"],
             dircmp.common
         )
+
+        # compare MANIFEST
+        self.assertTrue(
+            filecmp.cmp(
+                f"{collated_mags.path}/MANIFEST",
+                f"{expected}/MANIFEST"
+            )
+        )


### PR DESCRIPTION
This PR fixes a bug where the MANIFEST file in the `SampleData[MAGs]` artifact generated by the `collate-sample-data-mags` action would contain only entires from the last artifact which was being collated (the manifests were being overwritten). Instead, the entries will now be appended to the MANIFEST found in the first artifact.