### PR TITLE
Dataframe to jsonl changes

### DIFF
--- a/q2_types/tabular/_deferred_setup/_transformers.py
+++ b/q2_types/tabular/_deferred_setup/_transformers.py
@@ -68,11 +68,12 @@ def _make_dtype_conversion(
 
     if from_type == 'datetime':
         if to_type == 'datetime':
-            df[column] = df[column].dt.strftime('%Y-%m-%dT%H:%M:%S')
+            df[column] = \
+                df[column].dt.strftime('%Y-%m-%dT%H:%M:%S').astype('string')
         elif to_type == 'date':
-            df[column] = df[column].dt.strftime('%Y-%m-%d')
+            df[column] = df[column].dt.strftime('%Y-%m-%d').astype('string')
         elif to_type == 'time':
-            df[column] = df[column].dt.strftime('T%H:%M:%S')
+            df[column] = df[column].dt.strftime('%H:%M:%S').astype('string')
         else:
             _unsupported_conversion_error()
     elif from_type == 'timedelta':
@@ -172,12 +173,28 @@ def _get_matching_jsonl_type(dataframe_column_type: str) -> str:
     raise ValueError(msg)
 
 
+def _copy_dataframe_with_attrs(df: pd.DataFrame) -> pd.DataFrame:
+    '''
+    '''
+    column_to_attrs = {}
+    for column in df.columns:
+        column_to_attrs[column] = df[column].attrs
+
+    df_copy = df.copy()
+    for column in df:
+        df[column].attrs = column_to_attrs[column]
+        df_copy[column].attrs = column_to_attrs[column]
+
+    return df_copy
+
+
 def table_jsonl_header(df: pd.DataFrame) -> str:
     header = {}
     header['doctype'] = dict(
         name='table.jsonl', format='application/x-json-lines', version='1.0')
     header['direction'] = 'row'
     header['style'] = 'key:value'
+
 
     fields = []
     for name in df.columns:
@@ -221,6 +238,8 @@ def table_jsonl_header(df: pd.DataFrame) -> str:
 
 @plugin.register_transformer
 def df_to_table_jsonl(obj: pd.DataFrame) -> TableJSONLFileFormat:
+    obj = _copy_dataframe_with_attrs(obj)
+
     header = table_jsonl_header(obj)
 
     ff = TableJSONLFileFormat()

--- a/q2_types/tabular/_deferred_setup/_transformers.py
+++ b/q2_types/tabular/_deferred_setup/_transformers.py
@@ -218,6 +218,42 @@ def _copy_dataframe_with_attrs(df: pd.DataFrame) -> pd.DataFrame:
     return df_copy
 
 
+def _process_dataframe_types(df: pd.DataFrame) -> pd.DataFrame:
+    '''
+    Processes a dataframe by annotating columns with their inferred data types
+    where no annotation exists, and by converting columns to the annotated type
+    where the annotated and inferred types do not match.
+
+    Parameters
+    ----------
+    pd.DataFrame
+        The dataframe to process. This dataframe is not mutated.
+
+    Returns
+    -------
+    pd.DataFrame
+        A new dataframe with updated annotations and column types as necessary.
+    '''
+    df = _copy_dataframe_with_attrs(df)
+
+    for column in df:
+        try:
+            attr_type = df[column].attrs['type']
+        except KeyError:
+            attr_type = None
+
+        df_type = _get_dataframe_column_type(df, column)
+
+        if attr_type is None:
+            df[column].attrs['type'] = df_type
+        else:
+            _make_dtype_conversion(
+                df, column, from_type=df_type, to_type=attr_type
+            )
+
+    return df
+
+
 def table_jsonl_header(df: pd.DataFrame) -> str:
     header = {}
     header['doctype'] = dict(
@@ -228,6 +264,7 @@ def table_jsonl_header(df: pd.DataFrame) -> str:
     fields = []
     for name in df.columns:
         attrs = df[name].attrs.copy()
+        attr_type = attrs.pop('type', None)
         title = attrs.pop('title', '')
         description = attrs.pop('description', '')
         missing = attrs.pop('missing', False)
@@ -235,20 +272,9 @@ def table_jsonl_header(df: pd.DataFrame) -> str:
         if extra is None:
             extra = attrs
 
-        attr_type = attrs.pop('type', None)
-        df_type = _get_dataframe_column_type(df, name)
-
-        if attr_type is None:
-            jsonl_type = df_type
-        else:
-            _make_dtype_conversion(
-                df, name, from_type=df_type, to_type=attr_type
-            )
-            jsonl_type = attr_type
-
         fields.append(dict(
             name=name,
-            type=jsonl_type,
+            type=attr_type,
             missing=missing,
             title=title,
             description=description,
@@ -266,17 +292,18 @@ def table_jsonl_header(df: pd.DataFrame) -> str:
 
 
 @plugin.register_transformer
-def df_to_table_jsonl(obj: pd.DataFrame) -> TableJSONLFileFormat:
-    obj = _copy_dataframe_with_attrs(obj)
-
-    header = table_jsonl_header(obj)
+def df_to_table_jsonl(df: pd.DataFrame) -> TableJSONLFileFormat:
+    processed_df = _process_dataframe_types(df)
+    header = table_jsonl_header(processed_df)
 
     ff = TableJSONLFileFormat()
     with ff.open() as fh:
         fh.write(header)
         fh.write('\n')
-        if not obj.empty:
-            obj.to_json(fh, orient='records', lines=True, date_format='iso')
+        if not processed_df.empty:
+            processed_df.to_json(
+                fh, orient='records', lines=True, date_format='iso'
+            )
 
     return ff
 

--- a/q2_types/tabular/_deferred_setup/_transformers.py
+++ b/q2_types/tabular/_deferred_setup/_transformers.py
@@ -222,8 +222,9 @@ def _get_matching_jsonl_type(dataframe_column_type: str) -> str:
 
 def _copy_dataframe_with_attrs(df: pd.DataFrame) -> pd.DataFrame:
     '''
-    Creates and returns a copy of dataframe including any column attrs.
-    Preserves the column attrs on the copied-from dataframe.
+    Creates and returns a copy of dataframe including any column attrs and
+    any dataframe-level attrs.
+    Preserves the column and dataframe attrs on the copied-from dataframe.
 
     Parameters
     ----------
@@ -235,12 +236,18 @@ def _copy_dataframe_with_attrs(df: pd.DataFrame) -> pd.DataFrame:
     df : pd.DataFrame
         The copied dataframe.
     '''
+    df_attrs = df.attrs
+
     column_to_attrs = {}
     for column in df.columns:
         column_to_attrs[column] = df[column].attrs
 
     df_copy = df.copy()
-    for column in df:
+
+    df.attrs = df.attrs
+    df_copy.attrs = df_attrs
+
+    for column in df.columns:
         df[column].attrs = column_to_attrs[column]
         df_copy[column].attrs = column_to_attrs[column]
 

--- a/q2_types/tabular/_deferred_setup/_transformers.py
+++ b/q2_types/tabular/_deferred_setup/_transformers.py
@@ -40,10 +40,11 @@ def _make_dtype_conversion(
         converted.
     from_type : str
         The datatype of the column in the dataframe. One of 'integer', 'float',
-        'string', 'datetime', 'timedelta'.
+        'string', 'boolean', 'datetime', 'timedelta'.
     to_type : str
         The datatype that the column should be converted to, if needed. One of
-        'integer', 'number', 'string', 'datetime', 'date', 'time', 'duration'.
+        'integer', 'number', 'string', 'boolean', 'datetime', 'date', 'time',
+        'duration'.
 
     Returns
     -------
@@ -73,10 +74,9 @@ def _make_dtype_conversion(
 
     if from_type == 'datetime':
         if to_type == 'datetime':
-            df[column] = \
-                df[column].dt.strftime('%Y-%m-%dT%H:%M:%S').astype('string')
+            pass
         elif to_type == 'date':
-            df[column] = df[column].dt.strftime('%Y-%m-%d').astype('string')
+            df[column] = pd.to_datetime(df[column].dt.strftime('%Y-%m-%d'))
         elif to_type == 'time':
             df[column] = df[column].dt.strftime('%H:%M:%S').astype('string')
         else:
@@ -102,6 +102,11 @@ def _make_dtype_conversion(
             df[column] = df[column].astype(str)
         else:
             _unsupported_conversion_error()
+    elif from_type == 'boolean':
+        if to_type == 'boolean':
+            pass
+        else:
+            _unsupported_conversion_error()
     elif from_type == 'string':
         if to_type in ('datetime', 'date', 'time'):
             try:
@@ -114,7 +119,7 @@ def _make_dtype_conversion(
                 raise ValueError(msg)
         elif to_type == 'duration':
             try:
-                # NOTE: need stricter timedelta criteria
+                # NOTE: do we want to only accept iso-format duration strings?
                 df[column] = pd.to_timedelta(df[column])
             except ValueError:
                 msg = (
@@ -126,11 +131,9 @@ def _make_dtype_conversion(
         if to_type == 'string':
             pass
         elif to_type == 'datetime':
-            df[column] = df[column].dt.strftime(
-                '%Y-%m-%dT%H:%M:%S'
-            ).astype('string')
+            df[column] = pd.to_datetime(df[column])
         elif to_type == 'date':
-            df[column] = df[column].dt.strftime('%Y-%m-%d').astype('string')
+            df[column] = pd.to_datetime(df[column].dt.strftime('%Y-%m-%d'))
         elif to_type == 'time':
             df[column] = df[column].dt.strftime('%H:%M:%S').astype('string')
         elif to_type == 'duration':
@@ -158,7 +161,7 @@ def _get_dataframe_column_type(df: pd.DataFrame, column: str) -> str:
     -------
     str
         The determined conceptual datatype. One of 'integer', 'float',
-        'string', 'datetime', or 'timedelta'.
+        'string', 'boolean', 'datetime', or 'timedelta'.
 
     Raises
     ------
@@ -175,6 +178,8 @@ def _get_dataframe_column_type(df: pd.DataFrame, column: str) -> str:
         return 'datetime'
     if pd.api.types.is_timedelta64_dtype(df[column]):
         return 'timedelta'
+    if pd.api.types.is_bool_dtype(df[column]):
+        return 'boolean'
 
     msg = (
         f'The type of the {column} column was not detected as any of the '
@@ -196,7 +201,7 @@ def _get_matching_jsonl_type(dataframe_column_type: str) -> str:
     -------
     str
         The corresponding jsonl type. One of 'integer', 'number', 'string',
-        'datetime', or 'duration'.
+        'boolean', 'datetime', or 'duration'.
 
     Raises
     ------
@@ -204,7 +209,7 @@ def _get_matching_jsonl_type(dataframe_column_type: str) -> str:
         If the input dataframe column type is not in the set of recognized
         conceptual types.
     '''
-    if dataframe_column_type in ('integer', 'string', 'datetime'):
+    if dataframe_column_type in ('integer', 'string', 'boolean', 'datetime'):
         return dataframe_column_type
     if dataframe_column_type == 'float':
         return 'number'

--- a/q2_types/tabular/_deferred_setup/_transformers.py
+++ b/q2_types/tabular/_deferred_setup/_transformers.py
@@ -21,6 +21,117 @@ from .. import (NDJSONFileFormat,
 from ...plugin_setup import plugin
 
 
+def _make_dtype_conversion(
+    df: pd.DataFrame, column: str, from_type: str, to_type: str
+):
+    '''
+    Converts the datatype of a column in a dataframe from `from_type` to
+    `to_type`. The set of `from_type` options are a set of conceptual types
+    that columns in the pandas dataframe may be, not actual python or pandas
+    or numpy types. The set of `to_type` options are a set of conceptual types
+    that columns in the jsonl format may be, not actual javascript types.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The dataframe being converted to jsonl.
+    column : str
+        The name of the column in the dataframe that is having its dtype
+        converted.
+    from_type : str
+        The datatype of the column in the dataframe. One of 'integer', 'float',
+        'string', 'datetime', 'duration'.
+    to_type : str
+        The datatype that the column should be converted to, if needed. One of
+        'integer', 'number', 'string', 'datetime', 'date', 'time', 'duration'.
+
+    Returns
+    -------
+    None
+        Potentially changes the dtype of `column` in `df`.
+    '''
+    def _unsupported_conversion_error():
+        msg = (
+            f'The {column} column of type {from_type} can not be converted to '
+            f'the {to_type} type.'
+        )
+        raise ValueError(msg)
+
+    if from_type == 'datetime':
+        if to_type == 'datetime':
+            df[column] = df[column].dt.strftime('%Y-%m-%dT%H:%M:%S')
+        elif to_type == 'date':
+            df[column] = df[column].dt.strftime('%Y-%m-%d')
+        elif to_type == 'time':
+            df[column] = df[column].dt.strftime('T%H:%M:%S')
+        else:
+            _unsupported_conversion_error()
+
+    elif from_type == 'timedelta':
+        if to_type == 'duration':
+            df[column] = df[column].apply(pd.Timedelta.isoformat)
+        else:
+            _unsupported_conversion_error()
+
+    elif from_type == 'integer':
+        if to_type == 'integer':
+            pass
+        elif to_type == 'number':
+            pass
+        elif to_type == 'string':
+            df[column] = df[column].astype(str)
+        else:
+            _unsupported_conversion_error()
+
+    elif from_type == 'float':
+        if to_type == 'number':
+            pass
+        if to_type == 'string':
+            df[column] = df[column].astype(str)
+        else:
+            _unsupported_conversion_error()
+
+    elif from_type == 'string':
+        if to_type in ('datetime', 'date', 'time'):
+            formats = ['%Y-%m-%dT%H:%M:%S', '%Y-%m-%d', '%H:%M:%S']
+            for format in formats:
+                try:
+                    df[column] = pd.to_datetime(df[column], format=format)
+                    break
+                except ValueError:
+                    continue
+            else:
+                msg = (
+                    f'The {column} column could not be parsed into any of '
+                    'datetime, date, or time representations.'
+                )
+                raise ValueError(msg)
+
+        if to_type == 'duration':
+            try:
+                # NOTE: need stricter timedelta criteria
+                df[column] = pd.to_timedelta(df[column])
+            except ValueError:
+                msg = (
+                    f'The {column} column could not be parsed into timedelta '
+                    'representations.'
+                )
+                raise ValueError(msg)
+
+        if to_type == 'string':
+            pass
+        elif to_type == 'datetime':
+            df[column] = df[column].dt.strftime('%Y-%m-%dT%H:%M:%S')
+        elif to_type == 'date':
+            df[column] = df[column].dt.strftime('%Y-%m-%d')
+        elif to_type == 'time':
+            df[column] = df[column].dt.strftime('%H:%M:%S')
+        elif to_type == 'duration':
+            df[column] = df[column].apply(pd.Timedelta.isoformat)
+        else:
+            _unsupported_conversion_error()
+
+
 def table_jsonl_header(df: pd.DataFrame) -> str:
     header = {}
     header['doctype'] = dict(

--- a/q2_types/tabular/_deferred_setup/_transformers.py
+++ b/q2_types/tabular/_deferred_setup/_transformers.py
@@ -61,6 +61,11 @@ def _make_dtype_conversion(
         )
         raise ValueError(msg)
 
+    # cache all column attrs
+    column_to_attrs = {}
+    for _column in df.columns:
+        column_to_attrs[_column] = df[_column].attrs
+
     if from_type == 'datetime':
         if to_type == 'datetime':
             df[column] = df[column].dt.strftime('%Y-%m-%dT%H:%M:%S')
@@ -70,13 +75,11 @@ def _make_dtype_conversion(
             df[column] = df[column].dt.strftime('T%H:%M:%S')
         else:
             _unsupported_conversion_error()
-
     elif from_type == 'timedelta':
         if to_type == 'duration':
             df[column] = df[column].apply(pd.Timedelta.isoformat)
         else:
             _unsupported_conversion_error()
-
     elif from_type == 'integer':
         if to_type == 'integer':
             pass
@@ -86,7 +89,6 @@ def _make_dtype_conversion(
             df[column] = df[column].astype(str)
         else:
             _unsupported_conversion_error()
-
     elif from_type == 'float':
         if to_type == 'number':
             pass
@@ -94,7 +96,6 @@ def _make_dtype_conversion(
             df[column] = df[column].astype(str)
         else:
             _unsupported_conversion_error()
-
     elif from_type == 'string':
         if to_type in ('datetime', 'date', 'time'):
             formats = ['%Y-%m-%dT%H:%M:%S', '%Y-%m-%d', '%H:%M:%S']
@@ -110,15 +111,14 @@ def _make_dtype_conversion(
                     'datetime, date, or time representations.'
                 )
                 raise ValueError(msg)
-
         elif to_type == 'duration':
             try:
                 # NOTE: need stricter timedelta criteria
                 df[column] = pd.to_timedelta(df[column])
             except ValueError:
                 msg = (
-                    f'The {column} column could not be parsed into timedelta '
-                    'representations.'
+                    f'The {column} column could not be parsed into the '
+                    'timedelta representation.'
                 )
                 raise ValueError(msg)
 
@@ -134,6 +134,10 @@ def _make_dtype_conversion(
             df[column] = df[column].apply(pd.Timedelta.isoformat)
         else:
             _unsupported_conversion_error()
+
+    # restore cached column attrs
+    for _column in df.columns:
+        df[_column].attrs = column_to_attrs[_column]
 
 
 def _get_dataframe_column_type(df: pd.DataFrame, column: str) -> str:
@@ -160,6 +164,7 @@ def _get_dataframe_column_type(df: pd.DataFrame, column: str) -> str:
 def _get_matching_jsonl_type(dataframe_column_type: str) -> str:
     '''
     '''
+    print('get matching type called', dataframe_column_type)
     if dataframe_column_type in ('integer', 'string', 'datetime'):
         return dataframe_column_type
     if dataframe_column_type == 'float':
@@ -200,8 +205,13 @@ def table_jsonl_header(df: pd.DataFrame) -> str:
             jsonl_type = attr_type
 
         fields.append(dict(
-            name=name, type=jsonl_type, missing=missing, title=title,
-            description=description, extra=extra))
+            name=name,
+            type=jsonl_type,
+            missing=missing,
+            title=title,
+            description=description,
+            extra=extra
+        ))
 
     header['fields'] = fields
     header['index'] = []
@@ -211,6 +221,20 @@ def table_jsonl_header(df: pd.DataFrame) -> str:
 
     # prevent whitespace after comma and colon
     return json.dumps(header, separators=(',', ':'))
+
+
+@plugin.register_transformer
+def df_to_table_jsonl(obj: pd.DataFrame) -> TableJSONLFileFormat:
+    header = table_jsonl_header(obj)
+
+    ff = TableJSONLFileFormat()
+    with ff.open() as fh:
+        fh.write(header)
+        fh.write('\n')
+        if not obj.empty:
+            obj.to_json(fh, orient='records', lines=True, date_format='iso')
+
+    return ff
 
 
 @plugin.register_transformer
@@ -256,20 +280,6 @@ def table_jsonl_to_df(ff: TableJSONLFileFormat) -> pd.DataFrame:
     df.attrs.update(attrs)
 
     return df
-
-
-@plugin.register_transformer
-def df_to_table_jsonl(obj: pd.DataFrame) -> TableJSONLFileFormat:
-    header = table_jsonl_header(obj)
-
-    ff = TableJSONLFileFormat()
-    with ff.open() as fh:
-        fh.write(header)
-        fh.write('\n')
-        if not obj.empty:
-            obj.to_json(fh, orient='records', lines=True, date_format='iso')
-
-    return ff
 
 
 @plugin.register_transformer

--- a/q2_types/tabular/_deferred_setup/_transformers.py
+++ b/q2_types/tabular/_deferred_setup/_transformers.py
@@ -71,7 +71,7 @@ def _make_dtype_conversion(
         if to_type == 'datetime':
             pass
         elif to_type == 'date':
-            df[column] = pd.to_datetime(df[column].dt.strftime('%Y-%m-%d'))
+            df[column] = df[column].dt.strftime('%Y-%m-%d').astype('string')
         elif to_type == 'time':
             df[column] = df[column].dt.strftime('%H:%M:%S').astype('string')
         else:
@@ -128,7 +128,7 @@ def _make_dtype_conversion(
         elif to_type == 'datetime':
             df[column] = pd.to_datetime(df[column])
         elif to_type == 'date':
-            df[column] = pd.to_datetime(df[column].dt.strftime('%Y-%m-%d'))
+            df[column] = df[column].dt.strftime('%Y-%m-%d').astype('string')
         elif to_type == 'time':
             df[column] = df[column].dt.strftime('%H:%M:%S').astype('string')
         elif to_type == 'duration':

--- a/q2_types/tabular/_deferred_setup/_transformers.py
+++ b/q2_types/tabular/_deferred_setup/_transformers.py
@@ -26,10 +26,8 @@ def _make_dtype_conversion(
 ):
     '''
     Converts the datatype of a column in a dataframe from `from_type` to
-    `to_type`. The set of `from_type` options are a set of conceptual types
-    that columns in the pandas dataframe may be, not actual python or pandas
-    or numpy types. The set of `to_type` options are a set of conceptual types
-    that columns in the jsonl format may be, not actual javascript types.
+    `to_type`. The `from_type` and `to_type` parameters may each be one of
+    'integer', 'number', 'string', 'boolean', 'datetime', or 'duration'.
 
     Parameters
     ----------
@@ -39,12 +37,9 @@ def _make_dtype_conversion(
         The name of the column in the dataframe that is having its dtype
         converted.
     from_type : str
-        The datatype of the column in the dataframe. One of 'integer', 'float',
-        'string', 'boolean', 'datetime', 'timedelta'.
+        The datatype of the column in the dataframe.
     to_type : str
-        The datatype that the column should be converted to, if needed. One of
-        'integer', 'number', 'string', 'boolean', 'datetime', 'date', 'time',
-        'duration'.
+        The datatype that the column should be converted to, if needed.
 
     Returns
     -------
@@ -54,7 +49,7 @@ def _make_dtype_conversion(
     Raises
     ------
     ValueError
-        If the conversion from `from_type` go `to_type` is not supported.
+        If the conversion from `from_type` to `to_type` is not supported.
     ValueError
         If a string `from_type` can not be parsed into a datetime `to_type`.
     ValueError
@@ -67,7 +62,7 @@ def _make_dtype_conversion(
         )
         raise ValueError(msg)
 
-    # cache all column attrs
+    # cache column attrs
     column_to_attrs = {}
     for _column in df.columns:
         column_to_attrs[_column] = df[_column].attrs
@@ -81,7 +76,7 @@ def _make_dtype_conversion(
             df[column] = df[column].dt.strftime('%H:%M:%S').astype('string')
         else:
             _unsupported_conversion_error()
-    elif from_type == 'timedelta':
+    elif from_type == 'duration':
         if to_type == 'duration':
             df[column] = df[column].apply(pd.Timedelta.isoformat)
         else:
@@ -95,7 +90,7 @@ def _make_dtype_conversion(
             df[column] = df[column].astype(str)
         else:
             _unsupported_conversion_error()
-    elif from_type == 'float':
+    elif from_type == 'number':
         if to_type == 'number':
             pass
         elif to_type == 'string':
@@ -148,7 +143,7 @@ def _make_dtype_conversion(
 
 def _get_dataframe_column_type(df: pd.DataFrame, column: str) -> str:
     '''
-    Determines the conceptual datatype of `column` in `df`.
+    Determines the conceptual jsonl datatype of `column` in `df`.
 
     Parameters
     ----------
@@ -160,8 +155,8 @@ def _get_dataframe_column_type(df: pd.DataFrame, column: str) -> str:
     Returns
     -------
     str
-        The determined conceptual datatype. One of 'integer', 'float',
-        'string', 'boolean', 'datetime', or 'timedelta'.
+        The determined conceptual datatype. One of 'integer', 'number',
+        'string', 'boolean', 'datetime', or 'duration'.
 
     Raises
     ------
@@ -171,52 +166,21 @@ def _get_dataframe_column_type(df: pd.DataFrame, column: str) -> str:
     if pd.api.types.is_integer_dtype(df[column]):
         return 'integer'
     if pd.api.types.is_float_dtype(df[column]):
-        return 'float'
+        return 'number'
     if pd.api.types.is_string_dtype(df[column]):
         return 'string'
+    if pd.api.types.is_bool_dtype(df[column]):
+        return 'boolean'
     if pd.api.types.is_datetime64_dtype(df[column]):
         return 'datetime'
     if pd.api.types.is_timedelta64_dtype(df[column]):
-        return 'timedelta'
-    if pd.api.types.is_bool_dtype(df[column]):
-        return 'boolean'
+        return 'duration'
 
     msg = (
         f'The type of the {column} column was not detected as any of the '
-        'following types: integer, float, string, datetime, or timedelta.'
+        'following types: integer, number, string, boolean, datetime, or '
+        'duration.'
     )
-    raise ValueError(msg)
-
-
-def _get_matching_jsonl_type(dataframe_column_type: str) -> str:
-    '''
-    Get the corresponding jsonl type for a dataframe type.
-
-    Parameters
-    ----------
-    dataframe_column_type : str
-        The conceptual type of a dataframe column.
-
-    Returns
-    -------
-    str
-        The corresponding jsonl type. One of 'integer', 'number', 'string',
-        'boolean', 'datetime', or 'duration'.
-
-    Raises
-    ------
-    ValueError
-        If the input dataframe column type is not in the set of recognized
-        conceptual types.
-    '''
-    if dataframe_column_type in ('integer', 'string', 'boolean', 'datetime'):
-        return dataframe_column_type
-    if dataframe_column_type == 'float':
-        return 'number'
-    if dataframe_column_type == 'timedelta':
-        return 'duration'
-
-    msg = f'Unrecognized dataframe column type: {dataframe_column_type}'
     raise ValueError(msg)
 
 
@@ -272,13 +236,13 @@ def table_jsonl_header(df: pd.DataFrame) -> str:
             extra = attrs
 
         attr_type = attrs.pop('type', None)
-        dataframe_type = _get_dataframe_column_type(df, name)
+        df_type = _get_dataframe_column_type(df, name)
 
         if attr_type is None:
-            jsonl_type = _get_matching_jsonl_type(dataframe_type)
+            jsonl_type = df_type
         else:
             _make_dtype_conversion(
-                df, name, from_type=dataframe_type, to_type=attr_type
+                df, name, from_type=df_type, to_type=attr_type
             )
             jsonl_type = attr_type
 

--- a/q2_types/tabular/_deferred_setup/_transformers.py
+++ b/q2_types/tabular/_deferred_setup/_transformers.py
@@ -244,7 +244,7 @@ def _copy_dataframe_with_attrs(df: pd.DataFrame) -> pd.DataFrame:
 
     df_copy = df.copy()
 
-    df.attrs = df.attrs
+    df.attrs = df_attrs
     df_copy.attrs = df_attrs
 
     for column in df.columns:

--- a/q2_types/tabular/_deferred_setup/_transformers.py
+++ b/q2_types/tabular/_deferred_setup/_transformers.py
@@ -334,9 +334,7 @@ def table_jsonl_to_df(ff: TableJSONLFileFormat) -> pd.DataFrame:
         elif spec['type'] == 'date':
             df[col] = pd.to_datetime(df[col], format='ISO8601')
         elif spec['type'] == 'time':
-            df[col] = pd.to_datetime(
-                df[col], format='mixed'
-            ).dt.time.astype('string')
+            df[col] = pd.to_datetime(df[col], format='mixed').dt.time
         elif spec['type'] == 'duration':
             df[col] = pd.to_timedelta(df[col])
         elif spec['type'] == 'string':

--- a/q2_types/tabular/_deferred_setup/_transformers.py
+++ b/q2_types/tabular/_deferred_setup/_transformers.py
@@ -52,7 +52,12 @@ def _make_dtype_conversion(
 
     Raises
     ------
-
+    ValueError
+        If the conversion from `from_type` go `to_type` is not supported.
+    ValueError
+        If a string `from_type` can not be parsed into a datetime `to_type`.
+    ValueError
+        If a string `from_type` can not be parsed into a duration `to_type`.
     '''
     def _unsupported_conversion_error():
         msg = (
@@ -140,6 +145,25 @@ def _make_dtype_conversion(
 
 def _get_dataframe_column_type(df: pd.DataFrame, column: str) -> str:
     '''
+    Determines the conceptual datatype of `column` in `df`.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The dataframe that contains the column of interest.
+    column : str
+        The name of the column of interest.
+
+    Returns
+    -------
+    str
+        The determined conceptual datatype. One of 'integer', 'float',
+        'string', 'datetime', or 'timedelta'.
+
+    Raises
+    ------
+    ValueError
+        If `column` was not detected as any of the conceptual data types.
     '''
     if pd.api.types.is_integer_dtype(df[column]):
         return 'integer'
@@ -161,6 +185,24 @@ def _get_dataframe_column_type(df: pd.DataFrame, column: str) -> str:
 
 def _get_matching_jsonl_type(dataframe_column_type: str) -> str:
     '''
+    Get the corresponding jsonl type for a dataframe type.
+
+    Parameters
+    ----------
+    dataframe_column_type : str
+        The conceptual type of a dataframe column.
+
+    Returns
+    -------
+    str
+        The corresponding jsonl type. One of 'integer', 'number', 'string',
+        'datetime', or 'duration'.
+
+    Raises
+    ------
+    ValueError
+        If the input dataframe column type is not in the set of recognized
+        conceptual types.
     '''
     if dataframe_column_type in ('integer', 'string', 'datetime'):
         return dataframe_column_type
@@ -175,6 +217,18 @@ def _get_matching_jsonl_type(dataframe_column_type: str) -> str:
 
 def _copy_dataframe_with_attrs(df: pd.DataFrame) -> pd.DataFrame:
     '''
+    Creates and returns a copy of dataframe including any column attrs.
+    Preserves the column attrs on the copied-from dataframe.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The dataframe to copy.
+
+    Returns
+    -------
+    df : pd.DataFrame
+        The copied dataframe.
     '''
     column_to_attrs = {}
     for column in df.columns:
@@ -194,7 +248,6 @@ def table_jsonl_header(df: pd.DataFrame) -> str:
         name='table.jsonl', format='application/x-json-lines', version='1.0')
     header['direction'] = 'row'
     header['style'] = 'key:value'
-
 
     fields = []
     for name in df.columns:

--- a/q2_types/tabular/_deferred_setup/_transformers.py
+++ b/q2_types/tabular/_deferred_setup/_transformers.py
@@ -98,17 +98,12 @@ def _make_dtype_conversion(
             _unsupported_conversion_error()
     elif from_type == 'string':
         if to_type in ('datetime', 'date', 'time'):
-            formats = ['%Y-%m-%dT%H:%M:%S', '%Y-%m-%d', '%H:%M:%S']
-            for format in formats:
-                try:
-                    df[column] = pd.to_datetime(df[column], format=format)
-                    break
-                except ValueError:
-                    continue
-            else:
+            try:
+                df[column] = pd.to_datetime(df[column])
+            except ValueError:
                 msg = (
-                    f'The {column} column could not be parsed from any of '
-                    'datetime, date, or time representations.'
+                    f'The {column} column could not be parsed into the '
+                    'datetime representation.'
                 )
                 raise ValueError(msg)
         elif to_type == 'duration':
@@ -125,13 +120,15 @@ def _make_dtype_conversion(
         if to_type == 'string':
             pass
         elif to_type == 'datetime':
-            df[column] = df[column].dt.strftime('%Y-%m-%dT%H:%M:%S')
+            df[column] = df[column].dt.strftime(
+                '%Y-%m-%dT%H:%M:%S'
+            ).astype('string')
         elif to_type == 'date':
-            df[column] = df[column].dt.strftime('%Y-%m-%d')
+            df[column] = df[column].dt.strftime('%Y-%m-%d').astype('string')
         elif to_type == 'time':
-            df[column] = df[column].dt.strftime('%H:%M:%S')
+            df[column] = df[column].dt.strftime('%H:%M:%S').astype('string')
         elif to_type == 'duration':
-            df[column] = df[column].apply(pd.Timedelta.isoformat)
+            df[column] = pd.to_timedelta(df[column])
         else:
             _unsupported_conversion_error()
 
@@ -164,7 +161,6 @@ def _get_dataframe_column_type(df: pd.DataFrame, column: str) -> str:
 def _get_matching_jsonl_type(dataframe_column_type: str) -> str:
     '''
     '''
-    print('get matching type called', dataframe_column_type)
     if dataframe_column_type in ('integer', 'string', 'datetime'):
         return dataframe_column_type
     if dataframe_column_type == 'float':
@@ -259,13 +255,17 @@ def table_jsonl_to_df(ff: TableJSONLFileFormat) -> pd.DataFrame:
         elif spec['type'] == 'number':
             df[col] = df[col].astype('float64')
         elif spec['type'] == 'datetime':
-            df[col] = pd.to_datetime(df[col], format='iso8601')
+            df[col] = pd.to_datetime(df[col], format='ISO8601')
         elif spec['type'] == 'date':
-            df[col] = pd.to_datetime(df[col], format='iso8601')
+            df[col] = pd.to_datetime(df[col], format='ISO8601')
         elif spec['type'] == 'time':
-            df[col] = pd.to_datetime(df[col], format='mixed').dt.time
+            df[col] = pd.to_datetime(
+                df[col], format='mixed'
+            ).dt.time.astype('string')
         elif spec['type'] == 'duration':
             df[col] = pd.to_timedelta(df[col])
+        elif spec['type'] == 'string':
+            df[col] = df[col].astype('string')
 
     # 3. set index
     if len(header['index']) > 0:

--- a/q2_types/tabular/_deferred_setup/_transformers.py
+++ b/q2_types/tabular/_deferred_setup/_transformers.py
@@ -40,7 +40,7 @@ def _make_dtype_conversion(
         converted.
     from_type : str
         The datatype of the column in the dataframe. One of 'integer', 'float',
-        'string', 'datetime', 'duration'.
+        'string', 'datetime', 'timedelta'.
     to_type : str
         The datatype that the column should be converted to, if needed. One of
         'integer', 'number', 'string', 'datetime', 'date', 'time', 'duration'.
@@ -49,6 +49,10 @@ def _make_dtype_conversion(
     -------
     None
         Potentially changes the dtype of `column` in `df`.
+
+    Raises
+    ------
+
     '''
     def _unsupported_conversion_error():
         msg = (
@@ -86,7 +90,7 @@ def _make_dtype_conversion(
     elif from_type == 'float':
         if to_type == 'number':
             pass
-        if to_type == 'string':
+        elif to_type == 'string':
             df[column] = df[column].astype(str)
         else:
             _unsupported_conversion_error()
@@ -102,12 +106,12 @@ def _make_dtype_conversion(
                     continue
             else:
                 msg = (
-                    f'The {column} column could not be parsed into any of '
+                    f'The {column} column could not be parsed from any of '
                     'datetime, date, or time representations.'
                 )
                 raise ValueError(msg)
 
-        if to_type == 'duration':
+        elif to_type == 'duration':
             try:
                 # NOTE: need stricter timedelta criteria
                 df[column] = pd.to_timedelta(df[column])
@@ -132,6 +136,41 @@ def _make_dtype_conversion(
             _unsupported_conversion_error()
 
 
+def _get_dataframe_column_type(df: pd.DataFrame, column: str) -> str:
+    '''
+    '''
+    if pd.api.types.is_integer_dtype(df[column]):
+        return 'integer'
+    if pd.api.types.is_float_dtype(df[column]):
+        return 'float'
+    if pd.api.types.is_string_dtype(df[column]):
+        return 'string'
+    if pd.api.types.is_datetime64_dtype(df[column]):
+        return 'datetime'
+    if pd.api.types.is_timedelta64_dtype(df[column]):
+        return 'timedelta'
+
+    msg = (
+        f'The type of the {column} column was not detected as any of the '
+        'following types: integer, float, string, datetime, or timedelta.'
+    )
+    raise ValueError(msg)
+
+
+def _get_matching_jsonl_type(dataframe_column_type: str) -> str:
+    '''
+    '''
+    if dataframe_column_type in ('integer', 'string', 'datetime'):
+        return dataframe_column_type
+    if dataframe_column_type == 'float':
+        return 'number'
+    if dataframe_column_type == 'timedelta':
+        return 'duration'
+
+    msg = f'Unrecognized dataframe column type: {dataframe_column_type}'
+    raise ValueError(msg)
+
+
 def table_jsonl_header(df: pd.DataFrame) -> str:
     header = {}
     header['doctype'] = dict(
@@ -144,13 +183,24 @@ def table_jsonl_header(df: pd.DataFrame) -> str:
         attrs = df[name].attrs.copy()
         title = attrs.pop('title', '')
         description = attrs.pop('description', '')
-        type = attrs.pop('type', None)
         missing = attrs.pop('missing', False)
         extra = attrs.pop('extra', None)
         if extra is None:
             extra = attrs
+
+        attr_type = attrs.pop('type', None)
+        dataframe_type = _get_dataframe_column_type(df, name)
+
+        if attr_type is None:
+            jsonl_type = _get_matching_jsonl_type(dataframe_type)
+        else:
+            _make_dtype_conversion(
+                df, name, from_type=dataframe_type, to_type=attr_type
+            )
+            jsonl_type = attr_type
+
         fields.append(dict(
-            name=name, type=type, missing=missing, title=title,
+            name=name, type=jsonl_type, missing=missing, title=title,
             description=description, extra=extra))
 
     header['fields'] = fields

--- a/q2_types/tabular/tests/test_transformers.py
+++ b/q2_types/tabular/tests/test_transformers.py
@@ -358,8 +358,8 @@ class TestDataframeToJsonlTypeHandling(TestPluginBase):
         copies a dataframe and its column attributes, and that it preserves
         the attributes in the copied-from dataframe.
         '''
-        self.df['integer_column'].attrs =  {'key': 'value'}
-        self.df['string_column'].attrs =  {'oompa': 'loompa'}
+        self.df['integer_column'].attrs = {'key': 'value'}
+        self.df['string_column'].attrs = {'oompa': 'loompa'}
 
         copied_df = _copy_dataframe_with_attrs(self.df)
 

--- a/q2_types/tabular/tests/test_transformers.py
+++ b/q2_types/tabular/tests/test_transformers.py
@@ -8,6 +8,7 @@
 import json
 
 import pandas as pd
+from pandas.testing import assert_series_equal
 
 from qiime2.plugin.testing import TestPluginBase
 from qiime2.plugin.util import transform
@@ -150,8 +151,15 @@ class TestDataframeToJsonlTypeHandling(TestPluginBase):
 
     def test_invalid_attr_type_errors(self):
         '''
+        Tests that columns with invalid type attrs produce an error.
         '''
-        pass
+        self.df['integer_column'].attrs['type'] = 'datetime'
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r'.*type integer can not be converted.*datetime.*'
+        ):
+            transform(self.df, to_type=TableJSONLFileFormat)
 
     def test_missing_attrs_inferred_properly(self):
         '''
@@ -176,5 +184,152 @@ class TestDataframeToJsonlTypeHandling(TestPluginBase):
             field = self.get_header_field(header_dict, column)
             self.assertEqual(field['type'], column_to_jsonl_type[column])
 
-    def test_type_conversions_from_dataframe_to_jsonl(self):
+    def test_invalid_dataframe_column_type_errors(self):
+        '''
+        Tests that a column of a type that is not in the set of supported
+        data types produces an error.
+        '''
+        self.df['integer_column'] = self.df['integer_column'].astype(bool)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r'.*type of the integer_column column was not detected as any of.*'
+        ):
+            transform(self.df, to_type=TableJSONLFileFormat)
+
+    def assert_proper_type_conversion(
+        self,
+        df: pd.DataFrame,
+        column: str,
+        expected_column: pd.Series
+    ):
+        '''
+        Transforms a dataframe to and back from the jsonl format then asserts
+        that a column of interest is stored as expected.
+        '''
+        jsonl = transform(df, to_type=TableJSONLFileFormat)
+        round_trip_df = transform(jsonl, to_type=pd.DataFrame)
+
+        print('round trip col', round_trip_df[column])
+        print('expected col', expected_column)
+        expected_column.name = column
+        assert_series_equal(round_trip_df[column], expected_column)
+
+    def test_integer_type_conversions(self):
+        '''
+        Tests that a column of the integer type can be converted to the number
+        and string types.
+        '''
+        self.df['integer_column'].attrs['type'] = 'number'
+        self.assert_proper_type_conversion(
+            self.df,
+            'integer_column',
+            pd.Series([1.0, 2.0, 3.0], dtype='float64')
+        )
+
+        self.df['integer_column'].attrs['type'] = 'string'
+        self.assert_proper_type_conversion(
+            self.df,
+            'integer_column',
+            pd.Series(['1', '2', '3'], dtype='string')
+        )
+
+    def test_float_type_conversions(self):
+        '''
+        Tests that a column of the float type can be converted to the number
+        type.
+        '''
+        self.df['float_column'].attrs['type'] = 'string'
+        self.assert_proper_type_conversion(
+            self.df,
+            'float_column',
+            pd.Series(['1.0', '2.5', '3.0'], dtype='string')
+        )
+
+    def test_string_type_conversions(self):
+        '''
+        Tests that columns of the string type can be converted to the datetime,
+        date, time, and duration types, whether in the corresponding formats
+        or not.
+        '''
+        df = pd.DataFrame({
+            'datetime': ['2025-06-02T13:00:00'],
+            'date': ['2025-06-02'],
+            'time': ['13:00:00'],
+            'duration': ['P7D7H7M7S'],
+        })
+
+        # immediately corresponding formats
+        df['datetime'].attrs['type'] = 'datetime'
+        self.assert_proper_type_conversion(
+            df,
+            'datetime',
+            pd.Series(
+                [pd.to_datetime('2025-06-02T13:00:00')],
+                dtype='datetime64[ns]'
+            )
+        )
+
+        df['date'].attrs['type'] = 'date'
+        self.assert_proper_type_conversion(
+            df,
+            'date',
+            pd.Series(
+                pd.to_datetime(['2025-06-02T00:00:00']),
+                dtype='datetime64[ns]'
+            )
+        )
+
+        df['time'].attrs['type'] = 'time'
+        self.assert_proper_type_conversion(
+            df,
+            'time',
+            pd.Series(['13:00:00'], dtype='string')
+        )
+
+        df['duration'].attrs['type'] = 'duration'
+        self.assert_proper_type_conversion(
+            df,
+            'duration',
+            pd.Series(pd.to_timedelta(['P7D7H7M7S']), dtype='timedelta64[ns]')
+        )
+
+        # non immediately corresponding formats
+        # NOTE: not all possible conversions are enumerated here
+        df['datetime'].attrs['type'] = 'time'
+        self.assert_proper_type_conversion(
+            df,
+            'datetime',
+            pd.Series(['13:00:00'], dtype='string')
+        )
+
+        df['date'].attrs['type'] = 'datetime'
+        self.assert_proper_type_conversion(
+            df,
+            'date',
+            pd.Series(
+                pd.to_datetime(['2025-06-02T00:00:00']), dtype='datetime64[ns]'
+            )
+        )
+
+        df['time'].attrs['type'] = 'datetime'
+        self.assert_proper_type_conversion(
+            df,
+            'time',
+            pd.Series(
+                pd.to_datetime(['13:00:00']), dtype='datetime64[ns]'
+            )
+        )
+
+    def test_datetime_type_conversions(self):
+        '''
+        '''
         pass
+
+    def test_type_conversions(self):
+        '''
+        '''
+        valid_conversions = {
+            'datetime': ('datetime', 'date', 'time'),
+            'timedelta': ('duration'),
+        }

--- a/q2_types/tabular/tests/test_transformers.py
+++ b/q2_types/tabular/tests/test_transformers.py
@@ -198,11 +198,11 @@ class TestDataframeToJsonlTypeHandling(TestPluginBase):
         Tests that a column of a type that is not in the set of supported
         data types produces an error.
         '''
-        self.df['integer_column'] = self.df['integer_column'].astype(bool)
+        self.df['float_column'] = self.df['float_column'].astype('category')
 
         with self.assertRaisesRegex(
             ValueError,
-            r'.*type of the integer_column column was not detected as any of.*'
+            r'.*type of the float_column column was not detected as any of.*'
         ):
             transform(self.df, to_type=TableJSONLFileFormat)
 
@@ -351,6 +351,25 @@ class TestDataframeToJsonlTypeHandling(TestPluginBase):
             'datetime_column',
             pd.Series(['00:00:00', '17:00:00', '00:00:00'], dtype='string')
         )
+
+    def test_boolean_type_round_trips(self):
+        '''
+        Tests that columns of the dtype bool are successfully round-tripped,
+        whether the type is annotated in the attrs, or inferred. Note that
+        the boolean type is not tested alongside the other types because
+        it is not convertable to any other types and no other types convert to
+        it.
+        '''
+        df = pd.DataFrame({
+            'bool': [True, False],
+            'crip': [False, True],
+        })
+        df['bool'].attrs['type'] = 'boolean'
+
+        jsonl = transform(df, to_type=TableJSONLFileFormat)
+        round_trip_df = transform(jsonl, to_type=pd.DataFrame)
+
+        assert_frame_equal(df, round_trip_df)
 
     def test_copy_dataframe_with_attrs(self):
         '''

--- a/q2_types/tabular/tests/test_transformers.py
+++ b/q2_types/tabular/tests/test_transformers.py
@@ -5,6 +5,7 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+import json
 
 import pandas as pd
 
@@ -72,7 +73,7 @@ class TestTransformers(TestPluginBase):
         pd.testing.assert_frame_equal(obs.to_dataframe(), exp)
 
 
-class TestDataframeToJsonlTypes(TestPluginBase):
+class TestDataframeToJsonlTypeHandling(TestPluginBase):
     package = 'q2_types.tabular.tests'
 
     def setUp(self):
@@ -94,6 +95,13 @@ class TestDataframeToJsonlTypes(TestPluginBase):
                 ['P0D5H', 'P420D', 'P7D24H60M60S']
             )
         })
+
+    def get_header_field(self, header: dict, name: str) -> dict:
+        for field in header['fields']:
+            if field['name'] == name:
+                return field
+
+        raise ValueError(f'The {name} field was not found in the header.')
 
     def test_that_dummy_df_has_intended_types(self):
         '''
@@ -121,14 +129,52 @@ class TestDataframeToJsonlTypes(TestPluginBase):
 
     def test_attrs_written_to_jsonl_header(self):
         '''
+        Tests that dataframe column attrs are written to the jsonl header
+        properly.
+        '''
+        self.df['integer_column'].attrs['type'] = 'integer'
+        self.df['float_column'].attrs['type'] = 'number'
+        self.df['string_column'].attrs['type'] = 'string'
+        self.df['datetime_column'].attrs['type'] = 'datetime'
+        self.df['timedelta_column'].attrs['type'] = 'duration'
 
+        jsonl = transform(self.df, to_type=TableJSONLFileFormat)
+
+        with open(jsonl.path, 'r') as fh:
+            header_line = fh.readline()
+            header_dict = json.loads(header_line)
+
+        for column in self.df.columns:
+            field = self.get_header_field(header_dict, column)
+            self.assertEqual(field['type'], self.df[column].attrs['type'])
+
+    def test_invalid_attr_type_errors(self):
+        '''
         '''
         pass
 
     def test_missing_attrs_inferred_properly(self):
         '''
+        Tests that dataframe columns that do not have attrs have their type
+        properly inferred and written to the jsonl header.
         '''
-        pass
+        column_to_jsonl_type = {
+            'integer_column': 'integer',
+            'float_column': 'number',
+            'string_column': 'string',
+            'datetime_column': 'datetime',
+            'timedelta_column': 'duration',
+        }
+
+        jsonl = transform(self.df, to_type=TableJSONLFileFormat)
+
+        with open(jsonl.path, 'r') as fh:
+            header_line = fh.readline()
+            header_dict = json.loads(header_line)
+
+        for column in self.df.columns:
+            field = self.get_header_field(header_dict, column)
+            self.assertEqual(field['type'], column_to_jsonl_type[column])
 
     def test_type_conversions_from_dataframe_to_jsonl(self):
         pass

--- a/q2_types/tabular/tests/test_transformers.py
+++ b/q2_types/tabular/tests/test_transformers.py
@@ -392,3 +392,42 @@ class TestDataframeToJsonlTypeHandling(TestPluginBase):
         self.assertEqual(self.df.attrs, {'yay': 'attrs'})
         self.assertEqual(self.df['integer_column'].attrs, {'key': 'value'})
         self.assertEqual(self.df['string_column'].attrs, {'oompa': 'loompa'})
+
+    def test_json_representations(self):
+        '''
+        Tests that the json representations of various data types are as
+        they are expected to be.
+        '''
+        self.df['boolean_column'] = [True, False, True]
+
+        jsonl = transform(self.df, to_type=TableJSONLFileFormat)
+        with open(str(jsonl)) as fh:
+            json_content = fh.read()
+
+        self.assertIn('"integer_column":1', json_content)
+        self.assertIn('"float_column":1.0', json_content)
+        self.assertIn('"string_column":"strings"', json_content)
+        self.assertIn('"boolean_column":true', json_content)
+        self.assertIn(
+            '"datetime_column":"2012-01-01T00:00:00.000"', json_content
+        )
+        self.assertIn(
+            '"datetime_column":"1998-03-14T00:00:00.000"', json_content
+        )
+        self.assertIn('"timedelta_column":"P420DT0H0M0S"', json_content)
+
+        # datetime to date
+        self.df['datetime_column'].attrs['type'] = 'date'
+        jsonl = transform(self.df, to_type=TableJSONLFileFormat)
+        with open(str(jsonl)) as fh:
+            json_content = fh.read()
+
+        self.assertIn('"datetime_column":"1998-03-14"', json_content)
+
+        # datetime to time
+        self.df['datetime_column'].attrs['type'] = 'time'
+        jsonl = transform(self.df, to_type=TableJSONLFileFormat)
+        with open(str(jsonl)) as fh:
+            json_content = fh.read()
+
+        self.assertIn('"datetime_column":"17:00:00"', json_content)

--- a/q2_types/tabular/tests/test_transformers.py
+++ b/q2_types/tabular/tests/test_transformers.py
@@ -8,7 +8,7 @@
 import json
 
 import pandas as pd
-from pandas.testing import assert_series_equal
+from pandas.testing import assert_series_equal, assert_frame_equal
 
 from qiime2.plugin.testing import TestPluginBase
 from qiime2.plugin.util import transform
@@ -16,6 +16,9 @@ import qiime2.metadata
 
 from q2_types.tabular.formats import (
     TabularDataResourceDirFmt, TableJSONLFileFormat,
+)
+from q2_types.tabular._deferred_setup._transformers import (
+    _copy_dataframe_with_attrs
 )
 
 
@@ -323,13 +326,43 @@ class TestDataframeToJsonlTypeHandling(TestPluginBase):
 
     def test_datetime_type_conversions(self):
         '''
+        Tests that a column of the datetime type can be converted to the
+        date and time types.
         '''
-        pass
+        self.df['datetime_column'].attrs['type'] = 'date'
+        self.assert_proper_type_conversion(
+            self.df,
+            'datetime_column',
+            pd.Series(
+                pd.to_datetime([
+                    '2012-01-01T00:00:00', '00:00:00', '1998-03-14T00:00:00'
+                ], format='mixed'),
+                dtype='datetime64[ns]'
+            )
+        )
 
-    def test_type_conversions(self):
+        self.df['datetime_column'].attrs['type'] = 'time'
+        self.assert_proper_type_conversion(
+            self.df,
+            'datetime_column',
+            pd.Series(['00:00:00', '17:00:00', '00:00:00'], dtype='string')
+        )
+
+    def test_copy_dataframe_with_attrs(self):
         '''
+        Tests that the `_copy_dataframe_with_attrs` function accurately
+        copies a dataframe and its column attributes, and that it preserves
+        the attributes in the copied-from dataframe.
         '''
-        valid_conversions = {
-            'datetime': ('datetime', 'date', 'time'),
-            'timedelta': ('duration'),
-        }
+        self.df['integer_column'].attrs =  {'key': 'value'}
+        self.df['string_column'].attrs =  {'oompa': 'loompa'}
+
+        copied_df = _copy_dataframe_with_attrs(self.df)
+
+        assert_frame_equal(copied_df, self.df)
+
+        self.assertEqual(copied_df['integer_column'].attrs, {'key': 'value'})
+        self.assertEqual(copied_df['string_column'].attrs, {'oompa': 'loompa'})
+
+        self.assertEqual(self.df['integer_column'].attrs, {'key': 'value'})
+        self.assertEqual(self.df['string_column'].attrs, {'oompa': 'loompa'})

--- a/q2_types/tabular/tests/test_transformers.py
+++ b/q2_types/tabular/tests/test_transformers.py
@@ -70,3 +70,65 @@ class TestTransformers(TestPluginBase):
                                        'faithpd_refdist.table.jsonl')
         exp = exp.set_index('id')
         pd.testing.assert_frame_equal(obs.to_dataframe(), exp)
+
+
+class TestDataframeToJsonlTypes(TestPluginBase):
+    package = 'q2_types.tabular.tests'
+
+    def setUp(self):
+        '''
+        Creates a dataframe with a column for each of the recognized dataframe
+        types for use in the other tests in this class.
+        '''
+        super().setUp()
+
+        self.df = pd.DataFrame({
+            'integer_column': [1, 2, 3],
+            'float_column': [1.0, 2.5, 3.0],
+            'string_column': ['i', 'like', 'strings'],
+            'datetime_column': pd.to_datetime(
+                ['2012-01-01T00:00:00', '17:00:00', '1998-03-14'],
+                format='mixed'
+            ),
+            'timedelta_column': pd.to_timedelta(
+                ['P0D5H', 'P420D', 'P7D24H60M60S']
+            )
+        })
+
+    def test_that_dummy_df_has_intended_types(self):
+        '''
+        Tests that the columns in the pandas dataframe created in the `setUp`
+        have the intended types. (Does not test any plugin behavior.)
+        '''
+        type_assertion_funcs = {
+            'integer': pd.api.types.is_integer_dtype,
+            'float': pd.api.types.is_float_dtype,
+            'string': pd.api.types.is_string_dtype,
+            'datetime': pd.api.types.is_datetime64_dtype,
+            'timedelta': pd.api.types.is_timedelta64_dtype,
+        }
+
+        for column in self.df.columns:
+            column_type = column.removesuffix('_column')
+
+            assert_func = type_assertion_funcs[column_type]
+            self.assertTrue(assert_func(self.df[column]))
+
+            for other_column_type in type_assertion_funcs:
+                if other_column_type != column_type:
+                    assert_not_func = type_assertion_funcs[other_column_type]
+                    self.assertFalse(assert_not_func(self.df[column]))
+
+    def test_attrs_written_to_jsonl_header(self):
+        '''
+
+        '''
+        pass
+
+    def test_missing_attrs_inferred_properly(self):
+        '''
+        '''
+        pass
+
+    def test_type_conversions_from_dataframe_to_jsonl(self):
+        pass

--- a/q2_types/tabular/tests/test_transformers.py
+++ b/q2_types/tabular/tests/test_transformers.py
@@ -73,8 +73,14 @@ class TestTransformers(TestPluginBase):
                                        'faithpd_refdist.table.jsonl')
         _, exp = self.transform_format(TableJSONLFileFormat, pd.DataFrame,
                                        'faithpd_refdist.table.jsonl')
+
         exp = exp.set_index('id')
-        pd.testing.assert_frame_equal(obs.to_dataframe(), exp)
+
+        obs = obs.to_dataframe()
+        obs.index = obs.index.astype('string')
+        obs['group'] = obs['group'].astype('string')
+
+        pd.testing.assert_frame_equal(obs, exp)
 
 
 class TestDataframeToJsonlTypeHandling(TestPluginBase):
@@ -213,8 +219,6 @@ class TestDataframeToJsonlTypeHandling(TestPluginBase):
         jsonl = transform(df, to_type=TableJSONLFileFormat)
         round_trip_df = transform(jsonl, to_type=pd.DataFrame)
 
-        print('round trip col', round_trip_df[column])
-        print('expected col', expected_column)
         expected_column.name = column
         assert_series_equal(round_trip_df[column], expected_column)
 

--- a/q2_types/tabular/tests/test_transformers.py
+++ b/q2_types/tabular/tests/test_transformers.py
@@ -291,7 +291,7 @@ class TestDataframeToJsonlTypeHandling(TestPluginBase):
         self.assert_proper_type_conversion(
             df,
             'time',
-            pd.Series(['13:00:00'], dtype='string')
+            pd.to_datetime(pd.Series(['13:00:00'])).dt.time
         )
 
         df['duration'].attrs['type'] = 'duration'
@@ -307,7 +307,7 @@ class TestDataframeToJsonlTypeHandling(TestPluginBase):
         self.assert_proper_type_conversion(
             df,
             'datetime',
-            pd.Series(['13:00:00'], dtype='string')
+            pd.to_datetime(pd.Series(['13:00:00'])).dt.time
         )
 
         df['date'].attrs['type'] = 'datetime'
@@ -349,7 +349,9 @@ class TestDataframeToJsonlTypeHandling(TestPluginBase):
         self.assert_proper_type_conversion(
             self.df,
             'datetime_column',
-            pd.Series(['00:00:00', '17:00:00', '00:00:00'], dtype='string')
+            pd.to_datetime(
+                pd.Series(['00:00:00', '17:00:00', '00:00:00'])
+            ).dt.time
         )
 
     def test_boolean_type_round_trips(self):

--- a/q2_types/tabular/tests/test_transformers.py
+++ b/q2_types/tabular/tests/test_transformers.py
@@ -374,9 +374,10 @@ class TestDataframeToJsonlTypeHandling(TestPluginBase):
     def test_copy_dataframe_with_attrs(self):
         '''
         Tests that the `_copy_dataframe_with_attrs` function accurately
-        copies a dataframe and its column attributes, and that it preserves
-        the attributes in the copied-from dataframe.
+        copies a dataframe and its column and dataframe-level attributes, and
+        that it preserves these attributes in the copied-from dataframe.
         '''
+        self.df.attrs = {'yay': 'attrs'}
         self.df['integer_column'].attrs = {'key': 'value'}
         self.df['string_column'].attrs = {'oompa': 'loompa'}
 
@@ -384,8 +385,10 @@ class TestDataframeToJsonlTypeHandling(TestPluginBase):
 
         assert_frame_equal(copied_df, self.df)
 
+        self.assertEqual(copied_df.attrs, {'yay': 'attrs'})
         self.assertEqual(copied_df['integer_column'].attrs, {'key': 'value'})
         self.assertEqual(copied_df['string_column'].attrs, {'oompa': 'loompa'})
 
+        self.assertEqual(self.df.attrs, {'yay': 'attrs'})
         self.assertEqual(self.df['integer_column'].attrs, {'key': 'value'})
         self.assertEqual(self.df['string_column'].attrs, {'oompa': 'loompa'})


### PR DESCRIPTION
Overhauls the type handling functionality while transforming between jsonl and pandas data frames. 

Motivated by a bug in ancombc2 that caused strings that contained only numeric characters to be loaded as ints when going from dataframe to jsonl and back to a dataframe.

Summary of the new behavior:
- column dtypes are converted to the type annotated in the column attrs when the dataframe type and attrs type disagree
- columns that do not have their type annotated in the attrs have it deduced and written to the jsonl header anyway
