### PR TITLE
ENH: add new type called FeatureTable[Unconstrained]

### DIFF
--- a/q2_types/feature_table/__init__.py
+++ b/q2_types/feature_table/__init__.py
@@ -10,9 +10,9 @@ from ._formats import (BIOMV100Format, BIOMV210Format, BIOMV100DirFmt,
                        BIOMV210DirFmt)
 from ._types import (FeatureTable, Frequency, RelativeFrequency,
                      PresenceAbsence, Composition, Balance,
-                     PercentileNormalized, Design, Normalized)
+                     PercentileNormalized, Design, Normalized, LogFrequency)
 
 __all__ = ['BIOMV100Format', 'BIOMV100DirFmt', 'FeatureTable', 'Frequency',
            'RelativeFrequency', 'PresenceAbsence', 'BIOMV210Format',
            'BIOMV210DirFmt', 'Composition', 'Balance', 'PercentileNormalized',
-           'Design', 'Normalized']
+           'Design', 'Normalized', 'LogFrequency']

--- a/q2_types/feature_table/__init__.py
+++ b/q2_types/feature_table/__init__.py
@@ -10,9 +10,9 @@ from ._formats import (BIOMV100Format, BIOMV210Format, BIOMV100DirFmt,
                        BIOMV210DirFmt)
 from ._types import (FeatureTable, Frequency, RelativeFrequency,
                      PresenceAbsence, Composition, Balance,
-                     PercentileNormalized, Design, Normalized, LogFrequency)
+                     PercentileNormalized, Design, Normalized, Unconstrained)
 
 __all__ = ['BIOMV100Format', 'BIOMV100DirFmt', 'FeatureTable', 'Frequency',
            'RelativeFrequency', 'PresenceAbsence', 'BIOMV210Format',
            'BIOMV210DirFmt', 'Composition', 'Balance', 'PercentileNormalized',
-           'Design', 'Normalized', 'LogFrequency']
+           'Design', 'Normalized', 'Unconstrained']

--- a/q2_types/feature_table/_deferred_setup/__init__.py
+++ b/q2_types/feature_table/_deferred_setup/__init__.py
@@ -27,7 +27,7 @@ plugin.register_views(BIOMV100Format, BIOMV210Format, BIOMV100DirFmt,
 
 plugin.register_semantic_types(FeatureTable, Frequency, RelativeFrequency,
                                PresenceAbsence, Balance, Composition,
-                               PercentileNormalized, Design, Normalized, 
+                               PercentileNormalized, Design, Normalized,
                                Unconstrained)
 
 plugin.register_artifact_class(

--- a/q2_types/feature_table/_deferred_setup/__init__.py
+++ b/q2_types/feature_table/_deferred_setup/__init__.py
@@ -15,7 +15,7 @@ from qiime2.plugin import Citations
 from .. import (BIOMV100Format, BIOMV210Format, BIOMV100DirFmt,
                 BIOMV210DirFmt, FeatureTable, Frequency, RelativeFrequency,
                 PresenceAbsence, Composition, Balance,
-                PercentileNormalized, Design, Normalized)
+                PercentileNormalized, Design, Normalized, LogFrequency)
 
 from ...plugin_setup import plugin
 
@@ -27,7 +27,7 @@ plugin.register_views(BIOMV100Format, BIOMV210Format, BIOMV100DirFmt,
 
 plugin.register_semantic_types(FeatureTable, Frequency, RelativeFrequency,
                                PresenceAbsence, Balance, Composition,
-                               PercentileNormalized, Design, Normalized)
+                               PercentileNormalized, Design, Normalized, LogFrequency)
 
 plugin.register_artifact_class(
     FeatureTable[Frequency],
@@ -81,5 +81,9 @@ plugin.register_artifact_class(
     directory_format=BIOMV210DirFmt,
     description="A feature table that was normalized."
 )
-
+plugin.register_artifact_class(
+    FeatureTable[LogFrequency],
+    directory_format=BIOMV210DirFmt,
+    description="A feature table that was log transformed."
+)
 importlib.import_module('._transformers', __name__)

--- a/q2_types/feature_table/_deferred_setup/__init__.py
+++ b/q2_types/feature_table/_deferred_setup/__init__.py
@@ -15,7 +15,7 @@ from qiime2.plugin import Citations
 from .. import (BIOMV100Format, BIOMV210Format, BIOMV100DirFmt,
                 BIOMV210DirFmt, FeatureTable, Frequency, RelativeFrequency,
                 PresenceAbsence, Composition, Balance,
-                PercentileNormalized, Design, Normalized, LogFrequency)
+                PercentileNormalized, Design, Normalized, Unconstrained)
 
 from ...plugin_setup import plugin
 
@@ -27,7 +27,7 @@ plugin.register_views(BIOMV100Format, BIOMV210Format, BIOMV100DirFmt,
 
 plugin.register_semantic_types(FeatureTable, Frequency, RelativeFrequency,
                                PresenceAbsence, Balance, Composition,
-                               PercentileNormalized, Design, Normalized, LogFrequency)
+                               PercentileNormalized, Design, Normalized, Unconstrained)
 
 plugin.register_artifact_class(
     FeatureTable[Frequency],
@@ -82,8 +82,10 @@ plugin.register_artifact_class(
     description="A feature table that was normalized."
 )
 plugin.register_artifact_class(
-    FeatureTable[LogFrequency],
+    FeatureTable[Unconstrained],
     directory_format=BIOMV210DirFmt,
-    description="A feature table that was log transformed."
+    description="A feature table containing real-valued feature "
+                "measurements represented in Euclidean space without "
+                "constant-sum (compositional) constraints."
 )
 importlib.import_module('._transformers', __name__)

--- a/q2_types/feature_table/_deferred_setup/__init__.py
+++ b/q2_types/feature_table/_deferred_setup/__init__.py
@@ -27,7 +27,8 @@ plugin.register_views(BIOMV100Format, BIOMV210Format, BIOMV100DirFmt,
 
 plugin.register_semantic_types(FeatureTable, Frequency, RelativeFrequency,
                                PresenceAbsence, Balance, Composition,
-                               PercentileNormalized, Design, Normalized, Unconstrained)
+                               PercentileNormalized, Design, Normalized, 
+                               Unconstrained)
 
 plugin.register_artifact_class(
     FeatureTable[Frequency],

--- a/q2_types/feature_table/_types.py
+++ b/q2_types/feature_table/_types.py
@@ -36,4 +36,4 @@ Normalized = SemanticType('Normalized',
                           variant_of=FeatureTable.field['content'])
 
 Unconstrained = SemanticType('Unconstrained',
-                                    variant_of=FeatureTable.field['content'])
+                             variant_of=FeatureTable.field['content'])

--- a/q2_types/feature_table/_types.py
+++ b/q2_types/feature_table/_types.py
@@ -35,5 +35,5 @@ Design = SemanticType('Design', variant_of=FeatureTable.field['content'])
 Normalized = SemanticType('Normalized',
                           variant_of=FeatureTable.field['content'])
 
-LogFrequency = SemanticType('LogFrequency',
+Unconstrained = SemanticType('Unconstrained',
                                     variant_of=FeatureTable.field['content'])

--- a/q2_types/feature_table/_types.py
+++ b/q2_types/feature_table/_types.py
@@ -34,3 +34,6 @@ Design = SemanticType('Design', variant_of=FeatureTable.field['content'])
 
 Normalized = SemanticType('Normalized',
                           variant_of=FeatureTable.field['content'])
+
+LogFrequency = SemanticType('LogFrequency',
+                                    variant_of=FeatureTable.field['content'])

--- a/q2_types/feature_table/tests/test_types.py
+++ b/q2_types/feature_table/tests/test_types.py
@@ -40,7 +40,7 @@ class TestTypes(TestPluginBase):
 
     def test_normalized_semantic_type_registration(self):
         self.assertRegisteredSemanticType(Normalized)
-        
+
     def test_unconstrained_semantic_type_registration(self):
         self.assertRegisteredSemanticType(Unconstrained)
 

--- a/q2_types/feature_table/tests/test_types.py
+++ b/q2_types/feature_table/tests/test_types.py
@@ -14,7 +14,7 @@ from q2_types.feature_table import (FeatureTable, Frequency,
                                     RelativeFrequency, PercentileNormalized,
                                     Composition, Balance,
                                     PresenceAbsence, BIOMV210DirFmt, Design,
-                                    Normalized)
+                                    Normalized, LogFrequency)
 
 
 class TestTypes(TestPluginBase):
@@ -40,6 +40,9 @@ class TestTypes(TestPluginBase):
 
     def test_normalized_semantic_type_registration(self):
         self.assertRegisteredSemanticType(Normalized)
+        
+    def test_log_frequency_semantic_type_registration(self):
+        self.assertRegisteredSemanticType(LogFrequency)
 
     def test_feature_table_semantic_type_to_v210_format_registration(self):
         self.assertSemanticTypeRegisteredToFormat(
@@ -65,6 +68,9 @@ class TestTypes(TestPluginBase):
             BIOMV210DirFmt)
         self.assertSemanticTypeRegisteredToFormat(
             FeatureTable[Normalized],
+            BIOMV210DirFmt)
+        self.assertSemanticTypeRegisteredToFormat(
+            FeatureTable[LogFrequency],
             BIOMV210DirFmt)
 
 

--- a/q2_types/feature_table/tests/test_types.py
+++ b/q2_types/feature_table/tests/test_types.py
@@ -14,7 +14,7 @@ from q2_types.feature_table import (FeatureTable, Frequency,
                                     RelativeFrequency, PercentileNormalized,
                                     Composition, Balance,
                                     PresenceAbsence, BIOMV210DirFmt, Design,
-                                    Normalized, LogFrequency)
+                                    Normalized, Unconstrained)
 
 
 class TestTypes(TestPluginBase):
@@ -41,8 +41,8 @@ class TestTypes(TestPluginBase):
     def test_normalized_semantic_type_registration(self):
         self.assertRegisteredSemanticType(Normalized)
         
-    def test_log_frequency_semantic_type_registration(self):
-        self.assertRegisteredSemanticType(LogFrequency)
+    def test_unconstrained_semantic_type_registration(self):
+        self.assertRegisteredSemanticType(Unconstrained)
 
     def test_feature_table_semantic_type_to_v210_format_registration(self):
         self.assertSemanticTypeRegisteredToFormat(
@@ -70,7 +70,7 @@ class TestTypes(TestPluginBase):
             FeatureTable[Normalized],
             BIOMV210DirFmt)
         self.assertSemanticTypeRegisteredToFormat(
-            FeatureTable[LogFrequency],
+            FeatureTable[Unconstrained],
             BIOMV210DirFmt)
 
 


### PR DESCRIPTION
closes #385 

Adds new type `FeatureTable[Unconstrained]` for a feature table containing real-valued feature measurements represented in Euclidean space without constant-sum (compositional) constraints. This can include, for example, a frequency table after CLR transformation or metabolomics intensity data.
