### PR TITLE
Add a file_dict method to the BamDirFmt and MultiBamDirFmt

### DIFF
--- a/q2_types/per_sample_sequences/_formats.py
+++ b/q2_types/per_sample_sequences/_formats.py
@@ -718,7 +718,8 @@ class BAMDirFmt(model.DirectoryFormat, FileDictMixin):
         return '%s.bam' % sample_id
 
 
-class MultiBAMDirFmt(MultiDirValidationMixin, model.DirectoryFormat, FileDictMixin):
+class MultiBAMDirFmt(MultiDirValidationMixin, model.DirectoryFormat,
+                     FileDictMixin):
     pathspec = r'.+\.bam$'
     suffixes = ['.bam']
     bams = model.FileCollection(r'.+\/.+\.bam', format=BAMFormat)

--- a/q2_types/per_sample_sequences/_formats.py
+++ b/q2_types/per_sample_sequences/_formats.py
@@ -24,7 +24,7 @@ from qiime2.plugin import ValidationError
 from q2_types.bowtie2 import Bowtie2IndexDirFmt
 from q2_types.feature_data import DNAFASTAFormat
 from ._util import _parse_sequence_filename, _manifest_to_df
-from .._util import FastqGzFormat
+from .._util import FastqGzFormat, FileDictMixin
 from ._util import validate_paired_ends_equal_record_count
 
 
@@ -708,7 +708,9 @@ class BAMFormat(model.BinaryFileFormat):
 
 
 # borrowed from q2-phylogenomics
-class BAMDirFmt(model.DirectoryFormat):
+class BAMDirFmt(model.DirectoryFormat, FileDictMixin):
+    pathspec = r'.+\.bam$'
+    suffixes = ['.bam']
     bams = model.FileCollection(r'.+\.bam', format=BAMFormat)
 
     @bams.set_path_maker
@@ -716,7 +718,9 @@ class BAMDirFmt(model.DirectoryFormat):
         return '%s.bam' % sample_id
 
 
-class MultiBAMDirFmt(MultiDirValidationMixin, model.DirectoryFormat):
+class MultiBAMDirFmt(MultiDirValidationMixin, model.DirectoryFormat, FileDictMixin):
+    pathspec = r'.+\.bam$'
+    suffixes = ['.bam']
     bams = model.FileCollection(r'.+\/.+\.bam', format=BAMFormat)
 
     @bams.set_path_maker

--- a/q2_types/per_sample_sequences/tests/test_formats.py
+++ b/q2_types/per_sample_sequences/tests/test_formats.py
@@ -858,6 +858,13 @@ class TestMultiFormats(TestPluginBase):
 
         format.validate()
 
+        file_dict = format.file_dict(relative=True)
+
+        assert file_dict == {
+            "sample1": "sample1.bam",
+            "sample2": "sample2.bam",
+        }
+
     @patch('subprocess.run', return_value=Mock(returncode=3))
     def test_bam_dirmt_invalid(self, p):
         # this patch is not ideal but samtools' installation sometimes can
@@ -876,6 +883,19 @@ class TestMultiFormats(TestPluginBase):
         format = MultiBAMDirFmt(filepath, mode='r')
 
         format.validate()
+
+        file_dict = format.file_dict(relative=True)
+
+        assert file_dict == {
+            "sample1": {
+                "map1": "sample1/map1.bam",
+                "map2": "sample1/map2.bam",
+            },
+            "sample2": {
+                "map1": "sample2/map1.bam",
+                "map2": "sample2/map2.bam",
+            },
+        }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a `file_dict` method to `BamDirFmt` and `MultiBamDirFmt`. These will be used by another action in q2-assembly, namely `sort-alignment-maps`, to simplify sample name and path handling.