### PR TITLE
FASTAFormat validator refactor

### DIFF
--- a/q2_types/feature_data/_formats.py
+++ b/q2_types/feature_data/_formats.py
@@ -156,20 +156,12 @@ class FASTAFormat(model.TextFileFormat):
         super().__init__(*args, **kwargs)
         self.aligned = False
         self.alphabet = None
+        self.one_sequence = False
 
     def _validate_(self, level):
         FASTAValidator, ValidationSet = _construct_validator_from_alphabet(
             self.alphabet)
         self._validate_FASTA(level, FASTAValidator, ValidationSet)
-
-    def _validate_line_lengths(
-            self, seq_len, prev_seq_len, prev_seq_start_line):
-        if prev_seq_len != seq_len:
-            raise ValidationError('The sequence starting on line '
-                                  f'{prev_seq_start_line} was length '
-                                  f'{prev_seq_len}. All previous sequences '
-                                  f'were length {seq_len}. All sequences must '
-                                  'be the same length for AlignedFASTAFormat.')
 
     def _validate_FASTA(self, level, FASTAValidator=None, ValidationSet=None):
         last_line_was_ID = False
@@ -183,6 +175,7 @@ class FASTAFormat(model.TextFileFormat):
         max_lines = level_map[level]
 
         with self.path.open('rb') as fh:
+            num_seqs = 0
             try:
                 first = fh.read(6)
                 if first[:3] == b'\xEF\xBB\xBF':
@@ -205,6 +198,7 @@ class FASTAFormat(model.TextFileFormat):
                     line = line.decode('utf-8-sig')
 
                     if line.startswith('>'):
+                        num_seqs += 1
                         if FASTAValidator and ValidationSet:
                             if seq_len == 0:
                                 seq_len = prev_seq_len
@@ -267,7 +261,9 @@ class FASTAFormat(model.TextFileFormat):
                 raise ValidationError(f'utf-8 cannot decode byte on line '
                                       f'{line_number}') from e
 
-        if self.aligned:
+        self.one_sequence = num_seqs == 1
+
+        if self.aligned and not self.one_sequence:
             self._validate_line_lengths(
                 seq_len, prev_seq_len, prev_seq_start_line)
 

--- a/q2_types/feature_data/_formats.py
+++ b/q2_types/feature_data/_formats.py
@@ -174,8 +174,8 @@ class FASTAFormat(model.TextFileFormat):
         max_lines = level_map[level]
 
         with self.path.open('rb') as fh:
-            num_seqs = 0
             try:
+                num_seqs = 0
                 first = fh.read(6)
                 if first[:3] == b'\xEF\xBB\xBF':
                     first = first[3:]

--- a/q2_types/feature_data/_formats.py
+++ b/q2_types/feature_data/_formats.py
@@ -156,7 +156,6 @@ class FASTAFormat(model.TextFileFormat):
         super().__init__(*args, **kwargs)
         self.aligned = False
         self.alphabet = None
-        self.one_sequence = False
 
     def _validate_(self, level):
         FASTAValidator, ValidationSet = _construct_validator_from_alphabet(
@@ -261,9 +260,7 @@ class FASTAFormat(model.TextFileFormat):
                 raise ValidationError(f'utf-8 cannot decode byte on line '
                                       f'{line_number}') from e
 
-        self.one_sequence = num_seqs == 1
-
-        if self.aligned and not self.one_sequence:
+        if self.aligned and num_seqs > 1:
             self._validate_line_lengths(
                 seq_len, prev_seq_len, prev_seq_start_line)
 


### PR DESCRIPTION
<!-- PR guidance and examples: https://github.com/rachis-org/governance/blob/main/pr_template_guidelines.md -->
<!-- rachis Generative AI Policy: https://github.com/rachis-org/governance/blob/main/ai_policy.md -->

# Description
<!-- REQUIRED: Briefly describe this PR, or link the issue it closes. -->
`FASTAFormat` validator fails if the there is only one sequence in the file, as `prev_seq_len` is set to the length of the sequence but `seq_len` is never set. Fixes this by counting the number of sequences in the file and skipping the final 
`_validate_line_lengths` if there is only one sequence (all sequences will be the same length since there is only one). Also addresses #393.

# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [X] NO AI USED.
- [ ] AI USED.


# AI Usage Details
<!-- REQUIRED if 'AI USED' is checked. This section can be deleted if 'NO AI USED' is checked. -->
