### PR TITLE
IMP: add Properties to NOG and Orthologs semantic types to distinguish contig and MAG-level annotations

### DIFF
--- a/q2_types/plugin_setup.py
+++ b/q2_types/plugin_setup.py
@@ -121,6 +121,7 @@ plugin.methods.register_function(
 
 
 ORTHOLOGS = TypeMatch([
+    SampleData[Orthologs],
     SampleData[Orthologs % Properties('contigs')],
     SampleData[Orthologs % Properties('mags')],
     SampleData[Orthologs % Properties('contigs', 'mags')],
@@ -192,6 +193,7 @@ plugin.methods.register_function(
 )
 
 NOGS = TypeMatch([
+    GenomeData[NOG],
     GenomeData[NOG % Properties('contigs')],
     GenomeData[NOG % Properties('mags')],
     GenomeData[NOG % Properties('contigs', 'mags')],

--- a/q2_types/plugin_setup.py
+++ b/q2_types/plugin_setup.py
@@ -120,11 +120,16 @@ plugin.methods.register_function(
 )
 
 
+ORTHOLOGS = TypeMatch([
+    SampleData[Orthologs % Properties('contigs')],
+    SampleData[Orthologs % Properties('mags')],
+    SampleData[Orthologs % Properties('contigs', 'mags')],
+])
 plugin.methods.register_function(
     function=q2_types.genome_data.partition_orthologs,
-    inputs={"orthologs": SampleData[Orthologs]},
+    inputs={"orthologs": ORTHOLOGS},
     parameters={"num_partitions": Int % Range(1, None)},
-    outputs={"partitioned_orthologs": Collection[SampleData[Orthologs]]},
+    outputs={"partitioned_orthologs": Collection[ORTHOLOGS]},
     input_descriptions={"orthologs": "The orthologs to partition."},
     parameter_descriptions={
         "num_partitions": "The number of partitions to split the MAGs"
@@ -176,9 +181,9 @@ plugin.methods.register_function(
 
 plugin.methods.register_function(
     function=q2_types.genome_data.collate_orthologs,
-    inputs={"orthologs": List[SampleData[Orthologs]]},
+    inputs={"orthologs": List[ORTHOLOGS]},
     parameters={},
-    outputs={"collated_orthologs": SampleData[Orthologs]},
+    outputs={"collated_orthologs": ORTHOLOGS},
     input_descriptions={"orthologs": "Orthologs to collate"},
     parameter_descriptions={},
     name="Collate orthologs",
@@ -186,11 +191,16 @@ plugin.methods.register_function(
                 "and collates them into a single artifact.",
 )
 
+NOGS = TypeMatch([
+    GenomeData[NOG % Properties('contigs')],
+    GenomeData[NOG % Properties('mags')],
+    GenomeData[NOG % Properties('contigs', 'mags')],
+])
 plugin.methods.register_function(
     function=q2_types.genome_data.collate_ortholog_annotations,
-    inputs={'ortholog_annotations': List[GenomeData[NOG]]},
+    inputs={'ortholog_annotations': List[NOGS]},
     parameters={},
-    outputs=[('collated_annotations', GenomeData[NOG])],
+    outputs=[('collated_annotations', NOGS)],
     input_descriptions={
         'ortholog_annotations': "Collection of ortholog annotations."
     },

--- a/q2_types/plugin_setup.py
+++ b/q2_types/plugin_setup.py
@@ -121,10 +121,10 @@ plugin.methods.register_function(
 
 
 ORTHOLOGS = TypeMatch([
-    SampleData[Orthologs],
-    SampleData[Orthologs % Properties('contigs')],
-    SampleData[Orthologs % Properties('mags')],
     SampleData[Orthologs % Properties('contigs', 'mags')],
+    SampleData[Orthologs % Properties('mags')],
+    SampleData[Orthologs % Properties('contigs')],
+    SampleData[Orthologs],
 ])
 plugin.methods.register_function(
     function=q2_types.genome_data.partition_orthologs,
@@ -193,10 +193,10 @@ plugin.methods.register_function(
 )
 
 NOGS = TypeMatch([
-    GenomeData[NOG],
-    GenomeData[NOG % Properties('contigs')],
-    GenomeData[NOG % Properties('mags')],
     GenomeData[NOG % Properties('contigs', 'mags')],
+    GenomeData[NOG % Properties('mags')],
+    GenomeData[NOG % Properties('contigs')],
+    GenomeData[NOG],
 ])
 plugin.methods.register_function(
     function=q2_types.genome_data.collate_ortholog_annotations,


### PR DESCRIPTION
<!-- PR guidance and examples: https://github.com/rachis-org/governance/blob/main/pr_template_guidelines.md -->
<!-- rachis Generative AI Policy: https://github.com/rachis-org/governance/blob/main/ai_policy.md -->

# Description
Adds `Properties` support to the `NOG` and `Orthologs` semantic types to allow distinguishing between contig-level and MAG-level eggNOG annotations.
Relates to  `transfer-eggnog-annotations` pipeline in q2-annotate (bokulich-lab/q2-annotate#359).

<!-- REQUIRED: Briefly describe this PR, or link the issue it closes. -->


# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [x] NO AI USED.
- [ ] AI USED.


# AI Usage Details
<!-- REQUIRED if 'AI USED' is checked. This section can be deleted if 'NO AI USED' is checked. -->
